### PR TITLE
Store 지도, 상세정보 개선 및 장바구니 개선

### DIFF
--- a/src/main/java/kr/co/solfood/owner/menu/OwnerMenuVO.java
+++ b/src/main/java/kr/co/solfood/owner/menu/OwnerMenuVO.java
@@ -10,4 +10,5 @@ public class OwnerMenuVO {
     private int menuPrice;
     private String menuMainimage;
     private String menuIntro;
+    private String menuExtra;
 }

--- a/src/main/java/kr/co/solfood/user/menu/MenuVO.java
+++ b/src/main/java/kr/co/solfood/user/menu/MenuVO.java
@@ -16,9 +16,9 @@ public class MenuVO {
     private String menuMainimage; // menu_mainimage
     private String menuIntro;     // menu_intro
     private String menuExtra;     // menu_extra - JSON 형태의 추가 옵션 정보
-    
+
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    
+
     // 카테고리 매핑 상수
     private static final Map<String, String> CATEGORY_KEYWORDS = Map.of(
         "프리미엄", "프리미엄",
@@ -30,7 +30,7 @@ public class MenuVO {
         "비빔밥", "비빔밥",
         "도시락", "도시락"
     );
-    
+
     // 메뉴명을 기반으로 카테고리를 결정하는 메서드 (개선됨)
     public String getCategory() {
         if (menuName == null) return "기타";
@@ -41,14 +41,14 @@ public class MenuVO {
             .findFirst()
             .orElse("신메뉴");
     }
-    
+
     /**
      * 메뉴 추가 옵션이 있는지 확인
      */
     public boolean hasExtraOptions() {
         return menuExtra != null && !menuExtra.trim().isEmpty() && !menuExtra.equals("{}");
     }
-    
+
     /**
      * 메뉴 추가 옵션을 Map으로 파싱
      */
@@ -56,76 +56,80 @@ public class MenuVO {
         if (!hasExtraOptions()) {
             return Map.of();
         }
-        
+
         try {
             return objectMapper.readValue(menuExtra, new TypeReference<Map<String, Object>>() {});
         } catch (JsonProcessingException e) {
             return Map.of();
         }
     }
-    
+
     /**
      * 선택된 옵션들의 추가 가격 계산
-     * @param selectedOptions 선택된 옵션들 (JSON 문자열) 예: {"사이즈": "대"}
+     * @param selectedOptions 선택된 옵션들 (JSON 문자열) 예: {"사이즈": "대", "토핑": ["치즈", "계란"]}
      * @return 추가 가격
      */
     public int calculateExtraPrice(String selectedOptions) {
         if (selectedOptions == null || selectedOptions.trim().isEmpty()) {
             return 0;
         }
-        
         try {
-            Map<String, Object> extraOptionsMap = getExtraOptionsAsMap();
             Map<String, Object> selected = objectMapper.readValue(selectedOptions, new TypeReference<Map<String, Object>>() {});
-            
-            // menu_extra 구조: {"options":[{"name":"사이즈","choices":[{"value":"소","price":0},{"value":"대","price":1000}]}]}
-            List<Map<String, Object>> options = (List<Map<String, Object>>) extraOptionsMap.get("options");
-            if (options == null) {
-                return 0;
-            }
-            
+            List<Map<String, Object>> optionGroups = objectMapper.readValue(menuExtra, new TypeReference<List<Map<String, Object>>>() {});
             int totalExtra = 0;
-            
-            // 선택된 옵션들을 순회
             for (Map.Entry<String, Object> selectedEntry : selected.entrySet()) {
-                String optionName = selectedEntry.getKey(); // 예: "사이즈"
-                Object selectedValue = selectedEntry.getValue(); // 예: "대"
-                
-                // menu_extra의 options에서 해당 이름의 옵션 찾기
-                for (Map<String, Object> option : options) {
-                    String name = (String) option.get("name");
-                    if (optionName.equals(name)) {
-                        List<Map<String, Object>> choices = (List<Map<String, Object>>) option.get("choices");
+                String groupName = selectedEntry.getKey().replaceAll("\\s+", "").toLowerCase().trim();
+                Object selectedValue = selectedEntry.getValue();
+                for (Map<String, Object> group : optionGroups) {
+                    String groupNameDb = ((String) group.get("groupName")).replaceAll("\\s+", "").toLowerCase().trim();
+                    if (groupName.equals(groupNameDb)) {
+                        List<Map<String, Object>> choices = (List<Map<String, Object>>) group.get("options");
                         if (choices != null) {
-                            for (Map<String, Object> choice : choices) {
-                                if (isChoiceSelected(choice, selectedValue)) {
-                                    Object priceObj = choice.get("price");
-                                    if (priceObj instanceof Number) {
-                                        totalExtra += ((Number) priceObj).intValue();
+                            if (selectedValue instanceof String) {
+                                String selectedStr = ((String) selectedValue).replaceAll("\\s+", "").toLowerCase().trim();
+                                for (Map<String, Object> choice : choices) {
+                                    String value = ((String) choice.get("name")).replaceAll("\\s+", "").toLowerCase().trim();
+                                    if (value.equals(selectedStr)) {
+                                        Object priceObj = choice.get("price");
+                                        if (priceObj instanceof Number) {
+                                            totalExtra += ((Number) priceObj).intValue();
+                                        }
+                                    }
+                                }
+                            } else if (selectedValue instanceof java.util.List) {
+                                for (Object sel : (java.util.List<?>) selectedValue) {
+                                    String selectedStr = sel.toString().replaceAll("\\s+", "").toLowerCase().trim();
+                                    for (Map<String, Object> choice : choices) {
+                                        String value = ((String) choice.get("name")).replaceAll("\\s+", "").toLowerCase().trim();
+                                        if (value.equals(selectedStr)) {
+                                            Object priceObj = choice.get("price");
+                                            if (priceObj instanceof Number) {
+                                                totalExtra += ((Number) priceObj).intValue();
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                        break; // 해당 옵션을 찾았으므로 더 이상 검색하지 않음
+                        break;
                     }
                 }
             }
-            
             return totalExtra;
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
             return 0;
         }
     }
-    
 
-    
+
+
     /**
      * 선택 항목이 선택되었는지 확인 (새로운 구조용)
      * 새로운 구조: {"value":"대","price":1000}
      */
     private boolean isChoiceSelected(Map<String, Object> choice, Object selectedValue) {
         Object choiceValue = choice.get("value");
-        
+
         if (selectedValue instanceof List) {
             // 다중 선택인 경우 (예: ["치즈", "계란"])
             List<?> selectedList = (List<?>) selectedValue;

--- a/src/main/java/kr/co/solfood/user/menu/MenuVO.java
+++ b/src/main/java/kr/co/solfood/user/menu/MenuVO.java
@@ -19,29 +19,6 @@ public class MenuVO {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    // 카테고리 매핑 상수
-    private static final Map<String, String> CATEGORY_KEYWORDS = Map.of(
-        "프리미엄", "프리미엄",
-        "정식", "정식시리즈",
-        "마요", "마요시리즈",
-        "카레", "카레",
-        "볶음밥", "볶음밥",
-        "덮밥", "덮밥",
-        "비빔밥", "비빔밥",
-        "도시락", "도시락"
-    );
-
-    // 메뉴명을 기반으로 카테고리를 결정하는 메서드 (개선됨)
-    public String getCategory() {
-        if (menuName == null) return "기타";
-        
-        return CATEGORY_KEYWORDS.entrySet().stream()
-            .filter(entry -> menuName.contains(entry.getKey()))
-            .map(Map.Entry::getValue)
-            .findFirst()
-            .orElse("신메뉴");
-    }
-
     /**
      * 메뉴 추가 옵션이 있는지 확인
      */

--- a/src/main/resources/kr/co/solfood/owner/menu/OwnerMenuMapper.xml
+++ b/src/main/resources/kr/co/solfood/owner/menu/OwnerMenuMapper.xml
@@ -11,27 +11,29 @@
             menu_name,
             menu_price,
             menu_mainimage,
-            menu_intro
+            menu_intro,
+            menu_extra
         )
         VALUES (
            #{storeId},
            #{menuName},
            #{menuPrice},
            #{menuMainimage},
-           #{menuIntro}
+           #{menuIntro},
+           #{menuExtra}
         )
     </insert>
 
     <!--메뉴 조회-->
     <select id="selectMenu" parameterType="int" resultType="kr.co.solfood.owner.menu.OwnerMenuVO">
-        SELECT menu_id,store_id,menu_name,menu_price,menu_mainimage,menu_intro
+        SELECT menu_id,store_id,menu_name,menu_price,menu_mainimage,menu_intro,menu_extra
         FROM menu
         WHERE store_id=#{storeId}
     </select>
 
     <!--메뉴 단건 조회-->
     <select id="getMenuById" parameterType="int" resultType="kr.co.solfood.owner.menu.OwnerMenuVO">
-        SELECT menu_id,store_id,menu_name,menu_price,menu_mainimage,menu_intro
+        SELECT menu_id,store_id,menu_name,menu_price,menu_mainimage,menu_intro,menu_extra
         FROM menu
         WHERE menu_id=#{menuId}
     </select>
@@ -44,7 +46,8 @@
             menu_name =#{menuName},
             menu_price =#{menuPrice},
             menu_mainimage =#{menuMainimage},
-            menu_intro =#{menuIntro}
+            menu_intro =#{menuIntro},
+            menu_extra =#{menuExtra}
         WHERE menu_id=#{menuId}
     </update>
 

--- a/src/main/webapp/WEB-INF/views/owner/addMenu.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/addMenu.jsp
@@ -445,6 +445,200 @@
     #preview img{width: 100%}
 
     #storeImagePreview{max-width: 700px}
+    #menuImagePreview{max-width: 700px}
+
+    /* 메뉴 옵션 스타일 (editMenu.jsp와 동일하게 복사) */
+    .menu-options-container {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      background: #f9f9f9;
+    }
+    .options-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #eee;
+    }
+    .options-description {
+      flex: 1;
+      margin-right: 20px;
+    }
+    .options-description h4 {
+      margin: 0 0 8px 0;
+      color: #333;
+      font-size: 1.1rem;
+    }
+    .options-description p {
+      margin: 0 0 12px 0;
+      color: #666;
+      font-size: 0.9rem;
+    }
+    .btn-add-option {
+      background: #22c55e;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background 0.3s ease;
+    }
+    .btn-add-option:hover {
+      background: #16a34a;
+    }
+    .option-group {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    .option-group-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #eee;
+    }
+    .option-group-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .group-number {
+      font-weight: 600;
+      color: #333;
+      font-size: 1rem;
+    }
+    .group-help {
+      font-size: 0.8rem;
+      color: #666;
+      font-weight: normal;
+    }
+    .btn-remove-group {
+      background: #ef4444;
+      color: white;
+      border: none;
+      padding: 4px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: background 0.3s ease;
+    }
+    .btn-remove-group:hover {
+      background: #dc2626;
+    }
+    .option-group-content {
+      margin-bottom: 20px;
+    }
+    .form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 20px;
+      margin-bottom: 15px;
+    }
+    .form-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .form-field label {
+      font-weight: 600;
+      color: #333;
+      font-size: 0.9rem;
+    }
+    .form-field input,
+    .form-field select {
+      padding: 8px 12px;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      font-size: 0.9rem;
+      transition: border-color 0.3s ease;
+    }
+    .form-field input:focus,
+    .form-field select:focus {
+      outline: none;
+      border-color: #22c55e;
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
+    }
+    .form-field small {
+      font-size: 0.75rem;
+      color: #666;
+      line-height: 1.3;
+    }
+    .option-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 10px;
+    }
+    .option-item {
+      background: #f8f9fa;
+      border: 1px solid #e9ecef;
+      border-radius: 8px;
+      padding: 15px;
+      margin-bottom: 15px;
+    }
+    .option-item-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 15px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #e9ecef;
+    }
+    .option-item-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .item-number {
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: #495057;
+    }
+    .item-help {
+      font-size: 0.75rem;
+      color: #6c757d;
+      font-weight: normal;
+    }
+    .btn-remove-option {
+      background: #dc3545;
+      color: white;
+      border: none;
+      padding: 2px 6px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 0.7rem;
+      transition: background 0.3s ease;
+    }
+    .btn-remove-option:hover {
+      background: #c82333;
+    }
+    .option-item-content {
+      margin-top: 10px;
+    }
+    .option-item-content .form-row {
+      grid-template-columns: 1fr 1fr;
+      gap: 15px;
+    }
+    .btn-add-option-item {
+      background: #6c757d;
+      color: white;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: background 0.3s ease;
+    }
+    .btn-add-option-item:hover {
+      background: #5a6268;
+    }
 
   </style>
 </head>
@@ -520,8 +714,6 @@
         <p>메뉴 정보를 등록할 수 있습니다 </p>
       </div>
 
-
-
       <div class="menu-content">
         <form id="menuForm" action="/solfood/owner/menu/add" method="post" enctype="multipart/form-data">
           <div class="form-group">
@@ -538,6 +730,26 @@
             <input type="text" id="menuIntro" name="menuIntro" required>
           </div>
 
+          <!-- 메뉴 추가 옵션 섹션 -->
+          <div class="form-group">
+            <label>메뉴 추가 옵션</label>
+            <div class="menu-options-container">
+              <div class="options-header">
+                <div class="options-description">
+                  <h4>🍽️ 메뉴 옵션 설정</h4>
+                  <p>고객이 메뉴 주문 시 선택할 수 있는 옵션들을 설정하세요.</p>
+                </div>
+                <button type="button" class="btn-add-option" id="addOptionGroupBtn">
+                  <span>➕ 옵션 그룹 추가</span>
+                </button>
+              </div>
+              <div id="optionsContainer">
+                <!-- 옵션 그룹들이 여기에 동적으로 추가됩니다 -->
+              </div>
+            </div>
+            <input type="hidden" id="menuExtraHidden" name="menuExtra" value="">
+          </div>
+
           <div class="form-group">
             <!-- 파일 선택 버튼 (label) -->
             <label for="menuMainimage">메뉴 이미지</label>
@@ -551,7 +763,6 @@
             <button type="button" class="btn-cancel" id="deleteImageBtn" onclick="deleteImagePreview()" style="display:none; margin-top: 10px;">이미지 삭제</button>
           </div>
 
-
           <div class="modal-actions">
             <button type="button" class="btn-cancel" onclick="location.href='/solfood/owner/menu'">취소</button>
             <button type="submit" class="btn-save">저장</button>
@@ -563,6 +774,7 @@
 
 </div>
 
+<script src="${pageContext.request.contextPath}/js/urlConstants.js"></script>
 <script src="${pageContext.request.contextPath}/js/s3Upload.js"></script>
 <script>
   function logout(){
@@ -608,6 +820,198 @@
     document.getElementById("menuMainimage").value = ""; // 파일 input 초기화
     document.getElementById("deleteImageBtn").style.display = "none"; // 미리보기 태그
   }
+
+  // 메뉴 옵션 관련 변수
+  let optionGroupCounter = 0;
+  let optionItemCounter = 0;
+
+  function addOptionGroup() {
+    optionGroupCounter++;
+    const groupId = 'optionGroup_' + optionGroupCounter;
+    const groupHtml =
+      '<div class="option-group" id="' + groupId + '">' +
+        '<div class="option-group-header">' +
+          '<div class="option-group-title">' +
+            '<span class="group-number">옵션 그룹</span>' +
+            '<span class="group-help">ℹ️ 고객이 선택할 옵션 그룹을 설정하세요</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-group" data-group-id="' + groupId + '">🗑️ 그룹 삭제</button>' +
+        '</div>' +
+        '<div class="option-group-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>📝 그룹명</label>' +
+              '<input type="text" class="group-name" placeholder="예: 사이드 선택, 맛 선택, 토핑 추가" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션 그룹의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>⚡ 필수 여부</label>' +
+              '<select class="group-required" onchange="updateMenuExtra()">' +
+                '<option value="false">선택사항 (고객이 선택하지 않아도 됨)</option>' +
+                '<option value="true">필수선택 (반드시 선택해야 함)</option>' +
+              '</select>' +
+              '<small>필수선택으로 설정하면 고객이 반드시 하나 이상 선택해야 주문이 가능합니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>🔢 최대 선택 개수</label>' +
+              '<input type="number" class="group-max" min="1" value="1" onchange="updateMenuExtra()">' +
+              '<small>고객이 이 그룹에서 최대 몇 개까지 선택할 수 있는지 설정합니다.</small>' +
+            '</div>' +
+          '</div>' +
+          '<div class="option-actions">' +
+            '<button type="button" class="btn-add-option-item" data-group-id="' + groupId + '">' +
+              '<span>➕ 옵션 추가</span>' +
+            '</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="option-items" id="optionItems_' + groupId + '">' +
+          '<!-- 옵션 아이템들이 여기에 추가됩니다 -->' +
+        '</div>' +
+      '</div>';
+    const container = document.getElementById('optionsContainer');
+    if (container) {
+      container.insertAdjacentHTML('beforeend', groupHtml);
+      const groupElement = document.getElementById(groupId);
+      if (groupElement) {
+        const removeGroupBtn = groupElement.querySelector('.btn-remove-group');
+        const addOptionBtn = groupElement.querySelector('.btn-add-option-item');
+        if (removeGroupBtn) {
+          removeGroupBtn.addEventListener('click', function() {
+            removeOptionGroup(groupId);
+          });
+        }
+        if (addOptionBtn) {
+          addOptionBtn.addEventListener('click', function() {
+            addOptionItem(groupId);
+          });
+        }
+      }
+    }
+  }
+
+  function removeOptionGroup(groupId) {
+    const element = document.getElementById(groupId);
+    if (element) {
+      element.remove();
+      updateMenuExtra();
+    }
+  }
+
+  function addOptionItem(groupId) {
+    optionItemCounter++;
+    const itemId = 'optionItem_' + optionItemCounter;
+    const itemHtml =
+      '<div class="option-item" id="' + itemId + '">' +
+        '<div class="option-item-header">' +
+          '<div class="option-item-title">' +
+            '<span class="item-number">옵션 ' + optionItemCounter + '</span>' +
+            '<span class="item-help">고객이 선택할 수 있는 개별 옵션입니다</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-option" data-item-id="' + itemId + '">🗑️ 삭제</button>' +
+        '</div>' +
+        '<div class="option-item-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>🍽️ 옵션명</label>' +
+              '<input type="text" class="option-name" placeholder="예: 감자튀김, 매운맛, 치즈 추가" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>💰 추가 가격</label>' +
+              '<input type="number" class="option-price" placeholder="0" value="0" onchange="updateMenuExtra()">' +
+              '<small>이 옵션을 선택했을 때 추가되는 가격입니다. (0원이면 무료)</small>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    const container = document.getElementById('optionItems_' + groupId);
+    if (container) {
+      container.insertAdjacentHTML('beforeend', itemHtml);
+      const itemElement = document.getElementById(itemId);
+      if (itemElement) {
+        const removeOptionBtn = itemElement.querySelector('.btn-remove-option');
+        if (removeOptionBtn) {
+          removeOptionBtn.addEventListener('click', function() {
+            removeOptionItem(itemId);
+          });
+        }
+      }
+    }
+  }
+
+  function removeOptionItem(itemId) {
+    const element = document.getElementById(itemId);
+    if (element) {
+      element.remove();
+      updateMenuExtra();
+    }
+  }
+
+  function updateMenuExtra() {
+    try {
+      const optionGroups = document.querySelectorAll('.option-group');
+      const menuExtraData = [];
+      optionGroups.forEach((group, groupIndex) => {
+        const groupNameElement = group.querySelector('.group-name');
+        const groupRequiredElement = group.querySelector('.group-required');
+        const groupMaxElement = group.querySelector('.group-max');
+        if (!groupNameElement || !groupRequiredElement || !groupMaxElement) {
+          return;
+        }
+        const groupName = groupNameElement.value;
+        const groupRequired = groupRequiredElement.value === 'true';
+        const groupMax = parseInt(groupMaxElement.value) || 1;
+        if (groupName.trim() === '') return;
+        const options = [];
+        const optionItems = group.querySelectorAll('.option-item');
+        optionItems.forEach((item) => {
+          const optionNameElement = item.querySelector('.option-name');
+          const optionPriceElement = item.querySelector('.option-price');
+          if (!optionNameElement || !optionPriceElement) {
+            return;
+          }
+          const optionName = optionNameElement.value;
+          const optionPrice = parseInt(optionPriceElement.value) || 0;
+          if (optionName.trim() !== '') {
+            options.push({
+              name: optionName,
+              price: optionPrice
+            });
+          }
+        });
+        if (options.length > 0) {
+          menuExtraData.push({
+            groupName: groupName,
+            required: groupRequired,
+            maxSelect: groupMax,
+            options: options
+          });
+        }
+      });
+      const menuExtraElement = document.getElementById('menuExtraHidden');
+      if (menuExtraElement) {
+        menuExtraElement.value = JSON.stringify(menuExtraData);
+      }
+    } catch (error) {
+      // 에러 무시
+    }
+  }
+
+  // 폼 제출 시 옵션 데이터 업데이트
+  document.addEventListener('DOMContentLoaded', function() {
+    const menuForm = document.getElementById('menuForm');
+    if (menuForm) {
+      menuForm.addEventListener('submit', function(e) {
+        updateMenuExtra();
+      });
+    }
+    
+    // 옵션 그룹 추가 버튼 이벤트 리스너
+    const addOptionGroupBtn = document.getElementById('addOptionGroupBtn');
+    if (addOptionGroupBtn) {
+      addOptionGroupBtn.addEventListener('click', addOptionGroup);
+    }
+  });
 
 
 </script>

--- a/src/main/webapp/WEB-INF/views/owner/editMenu.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/editMenu.jsp
@@ -446,6 +446,231 @@
 
     #menuImagePreview{max-width: 700px}
 
+    /* 메뉴 옵션 스타일 */
+    .menu-options-container {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      background: #f9f9f9;
+    }
+
+    .options-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #eee;
+    }
+
+    .options-description {
+      flex: 1;
+      margin-right: 20px;
+    }
+
+    .options-description h4 {
+      margin: 0 0 8px 0;
+      color: #333;
+      font-size: 1.1rem;
+    }
+
+    .options-description p {
+      margin: 0 0 12px 0;
+      color: #666;
+      font-size: 0.9rem;
+    }
+
+    .btn-add-option {
+      background: #22c55e;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background 0.3s ease;
+    }
+
+    .btn-add-option:hover {
+      background: #16a34a;
+    }
+
+    .option-group {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+
+    .option-group-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #eee;
+    }
+
+    .option-group-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .group-number {
+      font-weight: 600;
+      color: #333;
+      font-size: 1rem;
+    }
+
+    .group-help {
+      font-size: 0.8rem;
+      color: #666;
+      font-weight: normal;
+    }
+
+    .btn-remove-group {
+      background: #ef4444;
+      color: white;
+      border: none;
+      padding: 4px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: background 0.3s ease;
+    }
+
+    .btn-remove-group:hover {
+      background: #dc2626;
+    }
+
+    .option-group-content {
+      margin-bottom: 20px;
+    }
+
+    .form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 20px;
+      margin-bottom: 15px;
+    }
+
+    .form-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .form-field label {
+      font-weight: 600;
+      color: #333;
+      font-size: 0.9rem;
+    }
+
+    .form-field input,
+    .form-field select {
+      padding: 8px 12px;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      font-size: 0.9rem;
+      transition: border-color 0.3s ease;
+    }
+
+    .form-field input:focus,
+    .form-field select:focus {
+      outline: none;
+      border-color: #22c55e;
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
+    }
+
+    .form-field small {
+      font-size: 0.75rem;
+      color: #666;
+      line-height: 1.3;
+    }
+
+    .option-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 10px;
+    }
+
+    .option-item {
+      background: #f8f9fa;
+      border: 1px solid #e9ecef;
+      border-radius: 8px;
+      padding: 15px;
+      margin-bottom: 15px;
+    }
+
+    .option-item-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 15px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #e9ecef;
+    }
+
+    .option-item-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .item-number {
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: #495057;
+    }
+
+    .item-help {
+      font-size: 0.75rem;
+      color: #6c757d;
+      font-weight: normal;
+    }
+
+    .btn-remove-option {
+      background: #dc3545;
+      color: white;
+      border: none;
+      padding: 2px 6px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 0.7rem;
+      transition: background 0.3s ease;
+    }
+
+    .btn-remove-option:hover {
+      background: #c82333;
+    }
+
+    .option-item-content {
+      margin-top: 10px;
+    }
+
+    .option-item-content .form-row {
+      grid-template-columns: 1fr 1fr;
+      gap: 15px;
+    }
+
+    .btn-add-option-item {
+      background: #6c757d;
+      color: white;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: background 0.3s ease;
+    }
+
+    .btn-add-option-item:hover {
+      background: #5a6268;
+    }
+
   </style>
 </head>
 <c:if test="${not empty msg}">
@@ -540,30 +765,50 @@
             <input type="text" id="menuIntro" name="menuIntro" value="${menu.menuIntro}" required>
           </div>
 
+          <!-- 메뉴 추가 옵션 섹션 -->
+          <div class="form-group">
+            <label>메뉴 추가 옵션</label>
+            <div class="menu-options-container">
+              <div class="options-header">
+                <div class="options-description">
+                  <h4>🍽️ 메뉴 옵션 설정</h4>
+                  <p>고객이 메뉴 주문 시 선택할 수 있는 옵션들을 설정하세요.</p>
+                </div>
+                <button type="button" class="btn-add-option" id="addOptionGroupBtn">
+                  <span>➕ 옵션 그룹 추가</span>
+                </button>
+              </div>
+              <div id="optionsContainer">
+                <!-- 옵션 그룹들이 여기에 동적으로 추가됩니다 -->
+              </div>
+            </div>
+            <input type="hidden" id="menuExtraHidden" name="menuExtra" value="<c:out value='${menu.menuExtra}'/>">
+          </div>
+
           <div class="form-group">
             <!-- 파일 선택 버튼 (label) -->
             <label for="menuMainimage">메뉴 이미지</label>
             <input type="hidden" name="menuMainimage" id="menuMainimageId" value="${menu.menuMainimage}">
             <label for="menuMainimage" class="btn-cancel" style="display: inline-block; color: #fff; font-weight: 400">파일 선택</label>
-            <input class="btn-cancel" accept="image/*" type="file" id="menuMainimage" onchange="previewmenuMainimage(event)" style="display: none">
+            <input class="btn-cancel" accept="image/*" type="file" id="menuMainimage" style="display: none">
 
           </div>
           <div id="preview">
             <img id="menuImagePreview" src="${menu.menuMainimage}" alt="">
-            <button type="button" class="btn-cancel" id="deleteImageBtn" onclick="deleteImagePreview()" style="display:none; margin-top: 10px;">이미지 삭제</button>
+            <button type="button" class="btn-cancel" id="deleteImageBtn" style="display:none; margin-top: 10px;">이미지 삭제</button>
           </div>
 
 
           <div class="modal-actions">
 
 
-            <button type="button" class="btn-cancel" onclick="location.href='/solfood/owner/menu'">취소</button>
+            <button type="button" class="btn-cancel" id="cancelBtn">취소</button>
             <button type="submit" class="btn-save">저장</button>
           </div>
         </form>
         <form action="/solfood/owner/menu/delete" method="post" style="position: absolute; bottom: 0">
           <input type="hidden" name="menuId" value="${menu.menuId}">
-          <button type="submit" class="btn-cancel" onclick="return confirm('정말 삭제하시겠습니까?🥹')">삭제</button>
+          <button type="submit" class="btn-cancel" id="deleteMenuBtn">삭제</button>
         </form>
       </div>
     </section>
@@ -571,6 +816,7 @@
 
 </div>
 
+<script src="${pageContext.request.contextPath}/js/urlConstants.js"></script>
 <script src="${pageContext.request.contextPath}/js/s3Upload.js"></script>
 <script>
   function logout(){
@@ -614,7 +860,8 @@
     document.getElementById("preview").style.display = "block";
     document.getElementById("menuImagePreview").src = ""; // 미리보기 제거
     document.getElementById("menuMainimage").value = ""; // 파일 input 초기화
-    document.getElementById("deleteImageBtn").style.display = "none"; // 미리보기 태그
+    document.getElementById("menuMainimageId").value = ""; // hidden input 초기화
+    document.getElementById("deleteImageBtn").style.display = "none"; // 삭제 버튼 숨기기
   }
   // ----------------------페이지 로드시 미리보기 ----------------------------------------
   window.onload = function () {
@@ -623,7 +870,436 @@
       document.getElementById("preview").style.display = "block";
       document.getElementById("deleteImageBtn").style.display = "inline-block";
     }
+    
+    // 기존 메뉴 옵션 데이터 로드
+    loadExistingMenuOptions();
+    
+    // 옵션 그룹 추가 버튼 이벤트 리스너 설정
+    const addOptionGroupBtn = document.getElementById('addOptionGroupBtn');
+    if (addOptionGroupBtn) {
+      // 기존 이벤트 리스너 제거
+      addOptionGroupBtn.removeEventListener('click', addOptionGroup);
+      // 새로운 이벤트 리스너 추가
+      addOptionGroupBtn.addEventListener('click', addOptionGroup);
+    }
   };
+
+  // 메뉴 옵션 관련 변수
+  let optionGroupCounter = 0;
+  let optionItemCounter = 0;
+
+  // 기존 메뉴 옵션 데이터 로드
+  function loadExistingMenuOptions() {
+    const hiddenInput = document.getElementById('menuExtraHidden');
+    if (!hiddenInput || !hiddenInput.value) {
+      return;
+    }
+    
+    const menuExtraData = hiddenInput.value;
+    if (menuExtraData && menuExtraData.trim() !== "" && menuExtraData !== "null" && menuExtraData !== "undefined") {
+      try {
+        const options = JSON.parse(menuExtraData);
+        if (Array.isArray(options) && options.length > 0) {
+          // 기존 옵션 로드 시에는 카운터를 증가시키지 않음
+          options.forEach((group, index) => {
+            optionGroupCounter = index;
+            addOptionGroupWithData(group, false);
+          });
+          // 기존 옵션 로드 후 카운터를 올바르게 설정
+          optionGroupCounter = options.length;
+        }
+      } catch (e) {
+        console.error('메뉴 옵션 데이터 파싱 오류:', e);
+      }
+    }
+  }
+
+  // 기존 데이터로 옵션 그룹 추가
+  function addOptionGroupWithData(groupData, incrementCounter = true) {
+    if (!groupData || !groupData.groupName) {
+      return;
+    }
+    
+    if (incrementCounter) {
+      optionGroupCounter++;
+    }
+    const groupId = 'optionGroup_' + optionGroupCounter;
+    
+    const groupName = groupData.groupName || '';
+    const groupRequired = groupData.required || false;
+    const groupMaxSelect = groupData.maxSelect || 1;
+    
+    const groupHtml = 
+      '<div class="option-group" id="' + groupId + '">' +
+        '<div class="option-group-header">' +
+          '<div class="option-group-title">' +
+            '<span class="group-number">옵션 그룹</span>' +
+            '<span class="group-help">ℹ️ 고객이 선택할 옵션 그룹을 설정하세요</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-group" data-group-id="' + groupId + '">🗑️ 그룹 삭제</button>' +
+        '</div>' +
+        '<div class="option-group-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>📝 그룹명</label>' +
+              '<input type="text" class="group-name" placeholder="예: 사이드 선택, 맛 선택, 토핑 추가" value="' + groupName + '" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션 그룹의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>⚡ 필수 여부</label>' +
+              '<select class="group-required" onchange="updateMenuExtra()">' +
+                '<option value="false"' + (!groupRequired ? ' selected' : '') + '>선택사항 (고객이 선택하지 않아도 됨)</option>' +
+                '<option value="true"' + (groupRequired ? ' selected' : '') + '>필수선택 (반드시 선택해야 함)</option>' +
+              '</select>' +
+              '<small>필수선택으로 설정하면 고객이 반드시 하나 이상 선택해야 주문이 가능합니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>🔢 최대 선택 개수</label>' +
+              '<input type="number" class="group-max" min="1" value="' + groupMaxSelect + '" onchange="updateMenuExtra()">' +
+              '<small>고객이 이 그룹에서 최대 몇 개까지 선택할 수 있는지 설정합니다.</small>' +
+            '</div>' +
+          '</div>' +
+          '<div class="option-actions">' +
+            '<button type="button" class="btn-add-option-item" data-group-id="' + groupId + '">' +
+              '<span>➕ 옵션 추가</span>' +
+            '</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="option-items" id="optionItems_' + groupId + '">' +
+          '<!-- 옵션 아이템들이 여기에 추가됩니다 -->' +
+        '</div>' +
+      '</div>';
+    
+    const container = document.getElementById('optionsContainer');
+    if (container) {
+      container.insertAdjacentHTML('beforeend', groupHtml);
+      
+      // 이벤트 리스너 추가
+      const groupElement = document.getElementById(groupId);
+      if (groupElement) {
+        const removeGroupBtn = groupElement.querySelector('.btn-remove-group');
+        const addOptionBtn = groupElement.querySelector('.btn-add-option-item');
+        
+        if (removeGroupBtn) {
+          removeGroupBtn.addEventListener('click', function() {
+            removeOptionGroup(groupId);
+          });
+        }
+        
+        if (addOptionBtn) {
+          addOptionBtn.addEventListener('click', function() {
+            addOptionItem(groupId);
+          });
+        }
+      }
+      
+      // 기존 옵션 아이템들 추가
+      if (groupData.options && Array.isArray(groupData.options)) {
+        groupData.options.forEach((option) => {
+          addOptionItemWithData(groupId, option);
+        });
+      }
+    }
+  }
+
+  // 기존 데이터로 옵션 아이템 추가
+  function addOptionItemWithData(groupId, optionData) {
+    if (!optionData || !optionData.name) {
+      return;
+    }
+    
+    optionItemCounter++;
+    const itemId = 'optionItem_' + optionItemCounter;
+    
+    const optionName = optionData.name || '';
+    const optionPrice = optionData.price || 0;
+    
+    const itemHtml = 
+      '<div class="option-item" id="' + itemId + '">' +
+        '<div class="option-item-header">' +
+          '<div class="option-item-title">' +
+            '<span class="item-number">옵션 ' + optionItemCounter + '</span>' +
+            '<span class="item-help">고객이 선택할 수 있는 개별 옵션입니다</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-option" data-item-id="' + itemId + '">🗑️ 삭제</button>' +
+        '</div>' +
+        '<div class="option-item-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>🍽️ 옵션명</label>' +
+              '<input type="text" class="option-name" placeholder="예: 감자튀김, 매운맛, 치즈 추가" value="' + optionName + '" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>💰 추가 가격</label>' +
+              '<input type="number" class="option-price" placeholder="0" value="' + optionPrice + '" onchange="updateMenuExtra()">' +
+              '<small>이 옵션을 선택했을 때 추가되는 가격입니다. (0원이면 무료)</small>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    
+    const container = document.getElementById('optionItems_' + groupId);
+    if (container) {
+      container.insertAdjacentHTML('beforeend', itemHtml);
+      
+      // 이벤트 리스너 추가
+      const itemElement = document.getElementById(itemId);
+      if (itemElement) {
+        const removeOptionBtn = itemElement.querySelector('.btn-remove-option');
+        if (removeOptionBtn) {
+          removeOptionBtn.addEventListener('click', function() {
+            removeOptionItem(itemId);
+          });
+        }
+      }
+    }
+  }
+
+  // 옵션 그룹 추가
+  function addOptionGroup() {
+    optionGroupCounter++;
+    const groupId = 'optionGroup_' + optionGroupCounter;
+    
+    const groupHtml = 
+      '<div class="option-group" id="' + groupId + '">' +
+        '<div class="option-group-header">' +
+          '<div class="option-group-title">' +
+            '<span class="group-number">옵션 그룹</span>' +
+            '<span class="group-help">ℹ️ 고객이 선택할 옵션 그룹을 설정하세요</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-group" data-group-id="' + groupId + '">🗑️ 그룹 삭제</button>' +
+        '</div>' +
+        '<div class="option-group-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>📝 그룹명</label>' +
+              '<input type="text" class="group-name" placeholder="예: 사이드 선택, 맛 선택, 토핑 추가" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션 그룹의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>⚡ 필수 여부</label>' +
+              '<select class="group-required" onchange="updateMenuExtra()">' +
+                '<option value="false">선택사항 (고객이 선택하지 않아도 됨)</option>' +
+                '<option value="true">필수선택 (반드시 선택해야 함)</option>' +
+              '</select>' +
+              '<small>필수선택으로 설정하면 고객이 반드시 하나 이상 선택해야 주문이 가능합니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>🔢 최대 선택 개수</label>' +
+              '<input type="number" class="group-max" min="1" value="1" onchange="updateMenuExtra()">' +
+              '<small>고객이 이 그룹에서 최대 몇 개까지 선택할 수 있는지 설정합니다.</small>' +
+            '</div>' +
+          '</div>' +
+          '<div class="option-actions">' +
+            '<button type="button" class="btn-add-option-item" data-group-id="' + groupId + '">' +
+              '<span>➕ 옵션 추가</span>' +
+            '</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="option-items" id="optionItems_' + groupId + '">' +
+          '<!-- 옵션 아이템들이 여기에 추가됩니다 -->' +
+        '</div>' +
+      '</div>';
+    
+    const container = document.getElementById('optionsContainer');
+    if (container) {
+      container.insertAdjacentHTML('beforeend', groupHtml);
+      
+      // 이벤트 리스너 추가
+      const groupElement = document.getElementById(groupId);
+      if (groupElement) {
+        const removeGroupBtn = groupElement.querySelector('.btn-remove-group');
+        const addOptionBtn = groupElement.querySelector('.btn-add-option-item');
+        
+        if (removeGroupBtn) {
+          removeGroupBtn.addEventListener('click', function() {
+            removeOptionGroup(groupId);
+          });
+        }
+        
+        if (addOptionBtn) {
+          addOptionBtn.addEventListener('click', function() {
+            addOptionItem(groupId);
+          });
+        }
+      }
+    }
+  }
+
+  // 옵션 그룹 삭제
+  function removeOptionGroup(groupId) {
+    const element = document.getElementById(groupId);
+    if (element) {
+      element.remove();
+      updateMenuExtra();
+    }
+  }
+
+  // 옵션 아이템 추가
+  function addOptionItem(groupId) {
+    optionItemCounter++;
+    const itemId = 'optionItem_' + optionItemCounter;
+    
+    const itemHtml = 
+      '<div class="option-item" id="' + itemId + '">' +
+        '<div class="option-item-header">' +
+          '<div class="option-item-title">' +
+            '<span class="item-number">옵션 ' + optionItemCounter + '</span>' +
+            '<span class="item-help">고객이 선택할 수 있는 개별 옵션입니다</span>' +
+          '</div>' +
+          '<button type="button" class="btn-remove-option" data-item-id="' + itemId + '">🗑️ 삭제</button>' +
+        '</div>' +
+        '<div class="option-item-content">' +
+          '<div class="form-row">' +
+            '<div class="form-field">' +
+              '<label>🍽️ 옵션명</label>' +
+              '<input type="text" class="option-name" placeholder="예: 감자튀김, 매운맛, 치즈 추가" onchange="updateMenuExtra()">' +
+              '<small>고객에게 표시될 옵션의 이름입니다.</small>' +
+            '</div>' +
+            '<div class="form-field">' +
+              '<label>💰 추가 가격</label>' +
+              '<input type="number" class="option-price" placeholder="0" value="0" onchange="updateMenuExtra()">' +
+              '<small>이 옵션을 선택했을 때 추가되는 가격입니다. (0원이면 무료)</small>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    
+    const container = document.getElementById('optionItems_' + groupId);
+    if (container) {
+      container.insertAdjacentHTML('beforeend', itemHtml);
+      
+      // 이벤트 리스너 추가
+      const itemElement = document.getElementById(itemId);
+      if (itemElement) {
+        const removeOptionBtn = itemElement.querySelector('.btn-remove-option');
+        if (removeOptionBtn) {
+          removeOptionBtn.addEventListener('click', function() {
+            removeOptionItem(itemId);
+          });
+        }
+      }
+    }
+  }
+
+  // 옵션 아이템 삭제
+  function removeOptionItem(itemId) {
+    const element = document.getElementById(itemId);
+    if (element) {
+      element.remove();
+      updateMenuExtra();
+    }
+  }
+
+  // 메뉴 옵션 데이터를 JSON으로 변환하여 hidden input에 저장
+  function updateMenuExtra() {
+    try {
+      const optionGroups = document.querySelectorAll('.option-group');
+      const menuExtraData = [];
+      
+      optionGroups.forEach((group, groupIndex) => {
+        const groupNameElement = group.querySelector('.group-name');
+        const groupRequiredElement = group.querySelector('.group-required');
+        const groupMaxElement = group.querySelector('.group-max');
+        
+        if (!groupNameElement || !groupRequiredElement || !groupMaxElement) {
+          return;
+        }
+        
+        const groupName = groupNameElement.value;
+        const groupRequired = groupRequiredElement.value === 'true';
+        const groupMax = parseInt(groupMaxElement.value) || 1;
+        
+        if (groupName.trim() === '') return; // 그룹명이 없으면 건너뛰기
+        
+        const options = [];
+        const optionItems = group.querySelectorAll('.option-item');
+        
+        optionItems.forEach((item) => {
+          const optionNameElement = item.querySelector('.option-name');
+          const optionPriceElement = item.querySelector('.option-price');
+          
+          if (!optionNameElement || !optionPriceElement) {
+            return;
+          }
+          
+          const optionName = optionNameElement.value;
+          const optionPrice = parseInt(optionPriceElement.value) || 0;
+          
+          if (optionName.trim() !== '') {
+            options.push({
+              name: optionName,
+              price: optionPrice
+            });
+          }
+        });
+        
+        if (options.length > 0) {
+          menuExtraData.push({
+            groupName: groupName,
+            required: groupRequired,
+            maxSelect: groupMax,
+            options: options
+          });
+        }
+      });
+      
+      // JSON 문자열로 변환하여 hidden input에 저장
+          const menuExtraElement = document.getElementById('menuExtraHidden');
+    if (menuExtraElement) {
+      menuExtraElement.value = JSON.stringify(menuExtraData);
+    }
+    } catch (error) {
+      console.error('updateMenuExtra 오류:', error);
+    }
+  }
+
+  // 폼 제출 시 옵션 데이터 업데이트
+  document.addEventListener('DOMContentLoaded', function() {
+    const menuForm = document.getElementById('menuForm');
+    if (menuForm) {
+      menuForm.addEventListener('submit', function(e) {
+        updateMenuExtra();
+      });
+    }
+    
+
+    
+    // 이미지 업로드 이벤트 리스너
+    const menuMainimageInput = document.getElementById('menuMainimage');
+    if (menuMainimageInput) {
+      menuMainimageInput.addEventListener('change', function(event) {
+        previewmenuMainimage(event);
+      });
+    }
+    
+    // 이미지 삭제 버튼 이벤트 리스너
+    const deleteImageBtn = document.getElementById('deleteImageBtn');
+    if (deleteImageBtn) {
+      deleteImageBtn.addEventListener('click', function() {
+        deleteImagePreview();
+      });
+    }
+    
+    // 취소 버튼 이벤트 리스너
+    const cancelBtn = document.getElementById('cancelBtn');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', function() {
+        location.href = '/solfood/owner/menu';
+      });
+    }
+    
+    // 삭제 버튼 이벤트 리스너
+    const deleteMenuBtn = document.getElementById('deleteMenuBtn');
+    if (deleteMenuBtn) {
+      deleteMenuBtn.addEventListener('click', function(e) {
+        if (!confirm('정말 삭제하시겠습니까?🥹')) {
+          e.preventDefault();
+        }
+      });
+    }
+  });
 
 
 </script>

--- a/src/main/webapp/WEB-INF/views/owner/menu.jsp
+++ b/src/main/webapp/WEB-INF/views/owner/menu.jsp
@@ -591,6 +591,11 @@
                 <div class="menu-name">${item.menuName}</div>
                 <div class="menu-description">${item.menuIntro}</div>
                 <div class="menu-price">₩${item.menuPrice}</div>
+                <c:if test="${not empty item.menuExtra}">
+                  <div class="menu-options-info">
+                    <small style="color: #666;">📋 옵션 설정됨</small>
+                  </div>
+                </c:if>
               </div>
             </div>
           </c:forEach>

--- a/src/main/webapp/WEB-INF/views/user/cart/cart.jsp
+++ b/src/main/webapp/WEB-INF/views/user/cart/cart.jsp
@@ -47,7 +47,7 @@
                 
                 <!-- 장바구니 아이템들 -->
                 <c:forEach var="item" items="${cart.items}">
-                    <div class="cart-item" data-menu-id="${item.menuId}">
+                    <div class="cart-item" data-menu-id="${item.menuId}" data-total-price="${item.totalPrice}">
                         <div class="row align-items-center">
                             <!-- 메뉴 이미지 -->
                             <div class="col-auto">

--- a/src/main/webapp/WEB-INF/views/user/store/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/user/store/detail.jsp
@@ -15,6 +15,9 @@
     <title>가게 리뷰</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍽️</text></svg>">
+    
     <!-- 외부 CSS 파일 -->
     <link rel="stylesheet" href="${pageContext.request.contextPath}/css/storedetail.css">
     
@@ -114,11 +117,11 @@
             
             <!-- 상단 액션 바 -->
             <div class="action-bar">
-                <a href="${pageContext.request.contextPath}/user/store" class="back-btn">
+                <a href="javascript:void(0)" onclick="goBack()" class="back-btn">
                     <i class="back-icon">←</i>
                 </a>
                 <span class="store-title"><c:out value="${store.storeName}"/></span>
-                <a href="${pageContext.request.contextPath}/user/cart" class="cart-link">
+                <a href="javascript:void(0)" onclick="goToCart()" class="cart-link">
                     <i class="cart-icon">🛒</i>
                     <span class="cart-badge" style="display: none;">0</span>
                 </a>
@@ -136,25 +139,6 @@
         <div class="scrollable-content" data-has-reviews="${not empty reviewList ? 'true' : 'false'}">
             <!-- 메뉴 섹션 -->
             <div class="content-section active" id="menu-section">
-                <c:if test="${not empty menuList}">
-                    <!-- 카테고리 필터(수정 예정) -->
-                    <div class="category-filter">
-                        <div class="category-tabs">
-                            <button class="category-tab active" data-category="전체">전체</button>
-                            <button class="category-tab" data-category="프리미엄">프리미엄</button>
-                            <button class="category-tab" data-category="도시락">도시락</button>
-                            <button class="category-tab" data-category="정식시리즈">정식시리즈</button>
-                            <button class="category-tab" data-category="마요시리즈">마요시리즈</button>
-                            <button class="category-tab" data-category="카레">카레</button>
-                            <button class="category-tab" data-category="볶음밥">볶음밥</button>
-                            <button class="category-tab" data-category="덮밥">덮밥</button>
-                            <button class="category-tab" data-category="비빔밥">비빔밥</button>
-                            <button class="category-tab" data-category="실속반찬/단품">실속반찬/단품</button>
-                            <button class="category-tab" data-category="스낵/디저트">스낵/디저트</button>
-                            <button class="category-tab" data-category="신메뉴">신메뉴</button>
-                        </div>
-                    </div>
-                </c:if>
                 
                 <div class="menu-list">
                     <c:choose>
@@ -164,7 +148,6 @@
                         <c:otherwise>
                             <c:forEach var="menu" items="${menuList}">
                                 <div class="menu-item" 
-                                     data-category="<c:out value='${menu.category}'/>"
                                      data-menu-id="${menu.menuId}"
                                      data-menu-name="<c:out value='${menu.menuName}'/>"
                                      data-menu-intro="<c:out value='${menu.menuIntro}'/>"
@@ -189,28 +172,59 @@
                 </div>
             </div>
             
-            <!-- 지도 섹션 -->
+            <!-- 상세정보 섹션 -->
             <div class="content-section" id="map-section">
-                <!-- 가게 상세 정보를 지도 위쪽으로 이동 -->
-                <div class="store-info-header">
-                    <h3>🍽️ <c:out value="${store.storeName}"/></h3>
-                    <p>📍 <c:out value="${store.storeAddress}"/></p>
-                    <p>📞 <c:out value="${store.storeTel}"/></p>
-                    <c:if test="${not empty store.storeCategory}">
-                        <p>🍴 카테고리: <c:out value="${store.storeCategory}"/></p>
+                <!-- 가게 소개 섹션 -->
+                <div class="store-intro-section">
+                    <div class="store-intro-header">
+                        <h3>🍽️ <c:out value="${store.storeName}"/></h3>
+                        <c:if test="${not empty store.storeCategory}">
+                            <span class="store-category-badge"><c:out value="${store.storeCategory}"/></span>
+                        </c:if>
+                    </div>
+                    
+                    <c:if test="${not empty store.storeIntro}">
+                        <div class="store-intro-content">
+                            <h4>📝 가게 소개</h4>
+                            <p><c:out value="${store.storeIntro}"/></p>
+                        </div>
                     </c:if>
+                    
+                    <div class="store-contact-info">
+                        <div class="contact-item">
+                            <i class="contact-icon">📞</i>
+                            <span><c:out value="${store.storeTel}"/></span>
+                        </div>
+                        <div class="contact-item">
+                            <i class="contact-icon">📍</i>
+                            <span><c:out value="${store.storeAddress}"/></span>
+                        </div>
+                    </div>
                 </div>
                 
-                <div class="map-container">
-                    <div id="map">
-                        <div style="width:100%; height:100%; background:#f0f0f0; display:flex; align-items:center; justify-content:center; flex-direction:column;">
-                            <div style="background:white; padding:20px; border-radius:10px; box-shadow:0 2px 10px rgba(0,0,0,0.1); text-align:center; max-width:300px;">
-                                <h3 style="margin-bottom:15px; color:#333;">📍 가게 위치</h3>
-                                <p style="margin:5px 0; color:#666;"><c:out value="${store.storeAddress}"/></p>
-                                <p style="margin:5px 0; color:#666;">위도: <c:out value="${store.storeLatitude}"/></p>
-                                <p style="margin:5px 0; color:#666;">경도: <c:out value="${store.storeLongitude}"/></p>
-                                <div style="margin-top:15px;">
-                                    <button onclick="loadKakaoMap()" style="background:#fee500; color:#000; border:none; padding:8px 16px; border-radius:5px; margin-right:10px; cursor:pointer; font-weight:bold;">카카오맵 재시도</button>
+                <!-- 위치 및 도보 시간 섹션 -->
+                <div class="location-section">
+                    <div class="location-header">
+                        <h4>📍 위치 정보</h4>
+                        <div class="walking-time-info" id="walkingTimeInfo">
+                            <div class="walking-time-loading">
+                                <div class="spinner"></div>
+                                <span>도보 시간 계산 중...</span>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="map-container">
+                        <div id="map">
+                            <div style="width:100%; height:100%; background:#f0f0f0; display:flex; align-items:center; justify-content:center; flex-direction:column;">
+                                <div style="background:white; padding:20px; border-radius:10px; box-shadow:0 2px 10px rgba(0,0,0,0.1); text-align:center; max-width:300px;">
+                                    <h3 style="margin-bottom:15px; color:#333;">📍 가게 위치</h3>
+                                    <p style="margin:5px 0; color:#666;"><c:out value="${store.storeAddress}"/></p>
+                                    <p style="margin:5px 0; color:#666;">위도: <c:out value="${store.storeLatitude}"/></p>
+                                    <p style="margin:5px 0; color:#666;">경도: <c:out value="${store.storeLongitude}"/></p>
+                                    <div style="margin-top:15px;">
+                                        <button onclick="loadKakaoMap()" style="background:#fee500; color:#000; border:none; padding:8px 16px; border-radius:5px; margin-right:10px; cursor:pointer; font-weight:bold;">카카오맵 재시도</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/main/webapp/css/storedetail.css
+++ b/src/main/webapp/css/storedetail.css
@@ -382,30 +382,153 @@ body {
     font-weight: 600;
 }
 
-/* === 지도 섹션 === */
-.map-container {
-    padding: 30px 20px 60px 20px;
-}
-
-.store-info-header {
-    text-align: center;
-    margin-bottom: 20px;
+/* === 상세정보 섹션 === */
+.store-intro-section {
     padding: 20px;
     background: #fff;
+    margin-bottom: 16px;
     border-radius: 12px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.04);
 }
 
-.store-info-header h3 {
-    color: #333;
-    margin-bottom: 8px;
-    font-size: 1.3em;
+.store-intro-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #f0f0f0;
 }
 
-.store-info-header p {
+.store-intro-header h3 {
+    color: #333;
+    margin: 0;
+    font-size: 1.3em;
+    font-weight: 600;
+}
+
+.store-category-badge {
+    background: #fee500;
+    color: #000;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.8em;
+    font-weight: 500;
+}
+
+.store-intro-content {
+    margin-bottom: 20px;
+}
+
+.store-intro-content h4 {
+    color: #333;
+    margin: 0 0 8px 0;
+    font-size: 1.1em;
+    font-weight: 600;
+}
+
+.store-intro-content p {
     color: #666;
+    line-height: 1.6;
+    margin: 0;
     font-size: 0.95em;
-    line-height: 1.4;
+}
+
+.store-contact-info {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.contact-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+.contact-icon {
+    font-size: 16px;
+    width: 20px;
+    text-align: center;
+}
+
+.contact-item span {
+    color: #333;
+    font-size: 0.95em;
+}
+
+/* === 위치 섹션 === */
+.location-section {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    overflow: hidden;
+}
+
+.location-header {
+    padding: 20px 20px 0 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.location-header h4 {
+    color: #333;
+    margin: 0;
+    font-size: 1.1em;
+    font-weight: 600;
+}
+
+.walking-time-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.walking-time-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #666;
+    font-size: 0.9em;
+}
+
+.spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid #f3f3f3;
+    border-top: 2px solid #fee500;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.walking-time-result {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: #fee500;
+    border-radius: 20px;
+    color: #000;
+    font-size: 0.9em;
+    font-weight: 500;
+}
+
+.walking-time-result i {
+    font-size: 14px;
+}
+
+/* === 지도 섹션 === */
+.map-container {
+    padding: 20px;
 }
 
 #map {
@@ -546,44 +669,8 @@ body {
     font-size: 1.1em;
 }
 
-/* === 카테고리 필터 === */
-.category-filter {
-    padding: 20px 16px 0 16px;
-    background: #fff;
-}
 
-.category-tabs {
-    display: flex;
-    gap: 8px;
-    overflow-x: auto;
-    padding-bottom: 16px;
-}
 
-.category-tab {
-    background: #f8f9fa;
-    color: #666;
-    padding: 8px 16px;
-    border-radius: 20px;
-    font-size: 0.9em;
-    white-space: nowrap;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    border: 1px solid #e9ecef;
-}
-
-.category-tab.active {
-    background: #333;
-    color: #fff;
-    border-color: #333;
-}
-
-.category-tab:hover {
-    background: #e9ecef;
-}
-
-.category-tab.active:hover {
-    background: #444;
-}
 
 /* === 거리 정보 === */
 .distance-info {

--- a/src/main/webapp/js/cart.js
+++ b/src/main/webapp/js/cart.js
@@ -132,8 +132,6 @@ function addToCart(menuId, quantity = 1) {
     })
     .then(response => response.json())
     .then(data => {
-        console.log('🛒 장바구니 추가 응답:', data);
-        
         if (data.result === 'success') {
             if (btn) {
                 btn.innerHTML = '<i class="cart-icon">✅</i> 완료!';
@@ -147,7 +145,6 @@ function addToCart(menuId, quantity = 1) {
             }
             
             const cartCount = data.cartCount || data.count || 0;
-            console.log('🛒 장바구니 개수:', cartCount);
             
             if (document.getElementById('bottomCartBar')) {
                 setTimeout(() => fetchCartInfo(), 200);
@@ -278,15 +275,10 @@ function displayOptions() {
         const menuId = element.getAttribute('data-menu-id');
         const optionsScript = element.querySelector('script.options-data');
         
-
-        
         let rawOptions = null;
         if (optionsScript) {
             rawOptions = optionsScript.textContent || optionsScript.innerText;
         }
-        
-
-
         
         // 안전한 옵션 표시
         let optionHtml = '';
@@ -352,7 +344,6 @@ function displayOptions() {
                     return;
                 }
             } catch (e) {
-                console.warn('옵션 파싱 실패:', e.message);
                 optionHtml = '<span class="option-item">⚙️ 옵션 오류</span>';
             }
         } else {
@@ -383,8 +374,6 @@ function fetchCartInfo() {
             const count = data.count || 0;
             const totalAmount = data.totalAmount || 0;
             
-            console.log('🛒 장바구니 정보:', { count, totalAmount });
-            
             SolFoodUtils.updateBadge('.cart-badge, .cart-nav-badge', count);
             updateBottomCartBar(count, totalAmount);
         })
@@ -406,41 +395,12 @@ function updateCartItemDisplay(menuId, quantity, totalAmount, cartCount) {
     const cartItem = document.querySelector(`[data-menu-id="${menuId}"]`);
     if (!cartItem) return;
     
-    console.log('🔄 가격 업데이트:', {menuId, quantity, totalAmount, cartCount});
-    
-    const quantityInput = cartItem.querySelector('.quantity-input');
-    if (quantityInput) {
-        quantityInput.value = quantity;
-        quantityInput.defaultValue = quantity;
-    }
-    
     const totalPriceElement = cartItem.querySelector('.fw-bold');
     if (totalPriceElement) {
-        // 개별 아이템 가격 계산을 위해 unitPrice 추출 개선
-        const itemPriceElement = cartItem.querySelector('.item-price');
-        if (itemPriceElement) {
-            let unitPrice = 0;
-            
-            // final-price가 있으면 (옵션 포함 가격) 그것을 사용
-            const finalPriceElement = itemPriceElement.querySelector('.final-price');
-            if (finalPriceElement) {
-                const finalPriceText = finalPriceElement.textContent || finalPriceElement.innerText;
-                unitPrice = parseInt(finalPriceText.replace(/[^0-9]/g, ''));
-                console.log('📊 옵션 포함 단가 사용:', unitPrice);
-            } else {
-                // 일반 가격 사용
-                const priceText = itemPriceElement.textContent || itemPriceElement.innerText;
-                unitPrice = parseInt(priceText.replace(/[^0-9]/g, ''));
-                console.log('📊 기본 단가 사용:', unitPrice);
-            }
-            
-            if (!isNaN(unitPrice) && unitPrice > 0) {
-                const itemTotal = unitPrice * quantity;
-                console.log('💰 계산된 아이템 총액:', itemTotal, '(단가:', unitPrice, 'x 수량:', quantity, ')');
-                totalPriceElement.textContent = SolFoodUtils.formatNumber(itemTotal) + '원';
-            } else {
-                console.warn('⚠️ 단가 추출 실패:', unitPrice);
-            }
+        // 서버에서 내려준 totalPrice를 그대로 사용
+        const totalPrice = cartItem.getAttribute('data-total-price');
+        if (totalPrice) {
+            totalPriceElement.textContent = SolFoodUtils.formatNumber(parseInt(totalPrice)) + '원';
         }
     }
     

--- a/src/main/webapp/js/cart.js
+++ b/src/main/webapp/js/cart.js
@@ -40,7 +40,7 @@ function updateQuantity(menuId, quantity) {
     
     const requestBody = `menuId=${numMenuId}&quantity=${numQuantity}`;
     
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/update'), {
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_UPDATE), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: requestBody
@@ -69,7 +69,7 @@ function removeItem(menuId) {
     
     const numMenuId = parseInt(menuId);
     
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/remove'), {
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_REMOVE), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: `menuId=${numMenuId}`
@@ -98,7 +98,7 @@ function clearCart() {
         return;
     }
     
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/clear'), {
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_CLEAR), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
     })
@@ -125,7 +125,7 @@ function addToCart(menuId, quantity = 1) {
         btn.innerHTML = '<i class="cart-icon">⏳</i> 추가중...';
     }
     
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/add'), {
+    fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_ADD), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: `menuId=${menuId}&quantity=${quantity}`
@@ -183,7 +183,7 @@ function addToCartWithOptions(cartItem) {
     
     const requestBody = `menuId=${cartItem.menuId}&quantity=${cartItem.quantity}&unitPrice=${unitPriceWithOptions}&options=${encodeURIComponent(optionsJson)}`;
     
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/add'), {
+    fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_ADD), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: requestBody
@@ -239,12 +239,12 @@ function updateBottomCartBar(count, totalAmount) {
 
 // 장바구니 페이지로 이동
 function goToCart() {
-    window.location.href = UrlConstants.Builder.fullUrl('/user/cart');
+    window.location.href = UrlConstants.Builder.fullUrl(UrlConstants.Pages.CART);
 }
 
 // 결제 페이지로 이동
 function proceedToPayment() {
-    window.location.href = UrlConstants.Builder.fullUrl('/user/cart/payment-method');
+    window.location.href = UrlConstants.Builder.fullUrl(UrlConstants.Pages.CART_PAYMENT_METHOD);
 }
 
 // 옵션 한글 매핑 상수
@@ -368,7 +368,7 @@ function displayOptions() {
 
 // 카트 정보 가져오기
 function fetchCartInfo() {
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/total'))
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_TOTAL))
         .then(response => response.json())
         .then(data => {
             const count = data.count || 0;
@@ -465,7 +465,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (document.getElementById('bottomCartBar')) {
         fetchCartInfo();
     } else {
-        fetch(UrlConstants.Builder.fullUrl('/user/cart/count'))
+        fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_COUNT))
             .then(response => response.json())
             .then(data => {
                 SolFoodUtils.updateBadge('.cart-badge, .cart-nav-badge', data.count || 0);

--- a/src/main/webapp/js/store.js
+++ b/src/main/webapp/js/store.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // 장바구니 개수 업데이트
     if (typeof updateCartBadge === 'function') {
-        fetch(UrlConstants.Builder.fullUrl('/user/cart/count'))
+        fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_COUNT))
             .then(response => response.json())
             .then(data => updateCartBadge(data.count || 0))
             .catch(error => console.error('장바구니 개수 로드 실패:', error));
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function() {
 // updateCartBadge 함수는 cart.js에서 제공됨
 
 function loadCategoryConfig() {
-    fetch(UrlConstants.Builder.fullUrl('/user/store/api/category/config'))
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.STORE_CATEGORY_CONFIG))
         .then(response => response.json())
         .then(data => {
             categoryConfig = data.data || data;
@@ -294,10 +294,10 @@ function loadStoreList() {
     let apiUrl;
 
     if (isSearchActive) {
-        apiUrl = UrlConstants.Builder.fullUrl(`/user/store/api/search?keyword=${encodeURIComponent(currentSearchKeyword)}&offset=${offset}&pageSize=${pageSize}&sort=${currentSort}`);
-    } else {
-        apiUrl = UrlConstants.Builder.fullUrl(`/user/store/api/list?category=${encodeURIComponent(currentCategory)}&offset=${offset}&pageSize=${pageSize}&sort=${currentSort}`);
-    }
+                    apiUrl = UrlConstants.Builder.fullUrl(`${UrlConstants.API.STORE_SEARCH}?keyword=${encodeURIComponent(currentSearchKeyword)}&offset=${offset}&pageSize=${pageSize}&sort=${currentSort}`);
+        } else {
+            apiUrl = UrlConstants.Builder.fullUrl(`${UrlConstants.API.STORE_LIST}?category=${encodeURIComponent(currentCategory)}&offset=${offset}&pageSize=${pageSize}&sort=${currentSort}`);
+        }
 
     fetch(apiUrl)
         .then(res => {
@@ -747,7 +747,7 @@ function goToStoreDetailFromMap(placeName, placeId) {
     document.body.appendChild(loadingOverlay);
 
     // 가게명으로 DB 검색
-    const searchUrl = UrlConstants.Builder.fullUrl(`/user/store/search/name?name=${encodeURIComponent(placeName)}`);
+    const searchUrl = UrlConstants.Builder.fullUrl(`${UrlConstants.API.STORE_SEARCH_BY_NAME}?name=${encodeURIComponent(placeName)}`);
     
     fetch(searchUrl)
         .then(response => response.json())
@@ -760,8 +760,8 @@ function goToStoreDetailFromMap(placeName, placeId) {
                 const store = data.stores[0];
                 window.location.href = UrlConstants.Builder.storeDetail(store.storeId);
             } else {
-                // 가게가 없는 경우 - 알람 표시 후 인포윈도우 닫기
-                alert(`'${placeName}' 가게를 찾을 수 없습니다.\n현재 Sol Food에 등록되지 않은 가게입니다.`);
+                // 가게가 없는 경우 - 모달 표시
+                showKakaoMapModal(placeName, placeId);
                 closeCurrentInfoWindow();
             }
         })
@@ -772,6 +772,137 @@ function goToStoreDetailFromMap(placeName, placeId) {
             alert('가게 정보를 확인하는 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.');
             closeCurrentInfoWindow();
         });
+}
+
+// ESC 키 이벤트 핸들러 (전역 변수)
+let kakaoMapModalEscHandler = null;
+
+// 카카오맵 모달 표시 함수
+function showKakaoMapModal(placeName, placeId) {
+    // 기존 모달이 있다면 제거
+    const existingModal = document.getElementById('kakaoMapModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    // 모달 생성
+    const modal = document.createElement('div');
+    modal.id = 'kakaoMapModal';
+    modal.style.cssText = `
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 10001;
+    `;
+    
+    // 모달 외부 클릭 시 닫기
+    modal.addEventListener('click', function(e) {
+        if (e.target === modal) {
+            closeKakaoMapModal();
+        }
+    });
+
+    modal.innerHTML = `
+        <div style="
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            max-width: 400px;
+            width: 90%;
+            text-align: center;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+        ">
+            <div style="margin-bottom: 20px;">
+                <div style="
+                    width: 60px;
+                    height: 60px;
+                    background: #fee500;
+                    border-radius: 50%;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    margin: 0 auto 16px;
+                ">
+                    <span style="font-size: 24px;">🗺️</span>
+                </div>
+                <h3 style="margin: 0 0 8px 0; color: #333; font-size: 18px;">카카오맵으로 이동</h3>
+                <p style="margin: 0; color: #666; font-size: 14px; line-height: 1.4;">
+                    '${placeName}' 가게는 현재 Sol Food에 등록되지 않았습니다.<br>
+                    카카오맵에서 자세한 정보를 확인하시겠습니까?
+                </p>
+            </div>
+            <div style="display: flex; gap: 12px; justify-content: center;">
+                <button onclick="closeKakaoMapModal()" style="
+                    padding: 12px 24px;
+                    border: 1px solid #ddd;
+                    background: white;
+                    color: #666;
+                    border-radius: 8px;
+                    font-size: 14px;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                " onmouseover="this.style.background='#f8f9fa'" onmouseout="this.style.background='white'">
+                    취소
+                </button>
+                <button onclick="openKakaoMap('${placeName}')" style="
+                    padding: 12px 24px;
+                    border: none;
+                    background: #fee500;
+                    color: #000;
+                    border-radius: 8px;
+                    font-size: 14px;
+                    font-weight: bold;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                " onmouseover="this.style.background='#f4d800'" onmouseout="this.style.background='#fee500'">
+                    카카오맵 열기
+                </button>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(modal);
+    
+    // ESC 키 이벤트 리스너 추가
+    kakaoMapModalEscHandler = function(e) {
+        if (e.key === 'Escape') {
+            closeKakaoMapModal();
+        }
+    };
+    document.addEventListener('keydown', kakaoMapModalEscHandler);
+}
+
+// 카카오맵 모달 닫기 함수
+function closeKakaoMapModal() {
+    const modal = document.getElementById('kakaoMapModal');
+    if (modal) {
+        modal.remove();
+    }
+    
+    // ESC 키 이벤트 리스너 정리
+    if (kakaoMapModalEscHandler) {
+        document.removeEventListener('keydown', kakaoMapModalEscHandler);
+        kakaoMapModalEscHandler = null;
+    }
+}
+
+// 카카오맵 열기 함수
+function openKakaoMap(placeName) {
+    // 카카오맵 URL 생성 (검색어로 검색)
+    const encodedPlaceName = encodeURIComponent(placeName);
+    const kakaoMapUrl = `https://map.kakao.com/link/search/${encodedPlaceName}`;
+    
+    // 새 창에서 카카오맵 열기
+    window.open(kakaoMapUrl, '_blank');
+    
+    // 모달 닫기
+    closeKakaoMapModal();
 }
 
 function callStore(phoneNumber) {

--- a/src/main/webapp/js/storedetail.js
+++ b/src/main/webapp/js/storedetail.js
@@ -62,8 +62,6 @@ function waitForKakaoMapSDK(callback, maxAttempts = 100) {
         } else if (attempts < maxAttempts) {
             setTimeout(check, 200); // 대기 시간 증가
         } else {
-            console.error('카카오맵 SDK 로딩 시간 초과');
-            kakaoMapLoading = false;
             callback(false);
         }
     }
@@ -91,13 +89,11 @@ function initMap() {
     try {
         const container = document.getElementById('map');
         if (!container) {
-            console.warn('지도 컨테이너를 찾을 수 없습니다.');
             return;
         }
         
         // 카카오맵 SDK 재확인
         if (!checkKakaoMapSDK()) {
-            console.error('카카오맵 SDK가 로드되지 않았습니다.');
             showMapError();
             return;
         }
@@ -110,7 +106,6 @@ function initMap() {
         
         // 좌표 유효성 검사
         if (isNaN(storeLatitude) || isNaN(storeLongitude)) {
-            console.error('유효하지 않은 좌표:', storeLatitude, storeLongitude);
             showMapError();
             return;
         }
@@ -139,10 +134,9 @@ function initMap() {
             content: '<div style="padding:5px;font-size:12px;">🍽️ ' + storeName + '</div>'
         });
         storeInfowindow.open(map, storeMarker);
-        
+
         kakaoMapLoaded = true;
     } catch (error) {
-        console.error('카카오맵 초기화 중 오류 발생:', error);
         showMapError();
     }
 }
@@ -154,7 +148,7 @@ function loadKakaoMap() {
     if (kakaoMapLoading) {
         return;
     }
-    
+
     kakaoMapLoading = true;
     
     // Promise 기반 SDK 로딩 사용
@@ -165,7 +159,6 @@ function loadKakaoMap() {
                 initMap();
             })
             .catch((error) => {
-                console.error('카카오맵 SDK 로딩 실패:', error);
                 kakaoMapLoading = false;
                 showMapError();
             });
@@ -397,7 +390,7 @@ function initializeStoreDetailPage() {
     // 장바구니 정보 업데이트
     setTimeout(() => {
         console.log('🔄 상세페이지 장바구니 초기화 시작');
-        
+
         if (document.getElementById('bottomCartBar') && typeof fetchCartInfo === 'function') {
             // 하단 카트 바가 있는 경우 총 금액도 함께 조회
             console.log('🛒 하단 카트 바 초기화');
@@ -412,12 +405,6 @@ function initializeStoreDetailPage() {
         }
     }, 100); // 모든 요소가 완전히 로드된 후 실행
 }
-
-/* ===========================
-   장바구니 관련 함수들
-   =========================== */
-
-// updateCartBadge 함수는 cart.js에서 제공됨
 
 /**
  * 페이지 로드 완료 후 초기화
@@ -486,8 +473,6 @@ let currentMenuData = {
     options: {}
 };
 
-
-
 /**
  * 메뉴 상세 모달 열기 (data 속성 방식)
  * @param {HTMLElement} element - 클릭된 메뉴 요소
@@ -499,7 +484,7 @@ function openMenuDetailFromElement(element) {
     const menuPrice = parseInt(element.dataset.menuPrice);
     const menuImage = element.dataset.menuImage;
     const menuExtra = element.dataset.menuExtra;
-    
+
     openMenuDetail(menuId, menuName, menuIntro, menuPrice, menuImage, menuExtra);
 }
 
@@ -524,30 +509,30 @@ function openMenuDetail(menuId, menuName, menuIntro, menuPrice, menuImage, menuE
         quantity: 1,
         options: {}
     };
-    
+
     // 모달 요소들 업데이트
     document.getElementById('modalMenuImage').src = menuImage || 'https://images.unsplash.com/photo-1590301157890-4810ed352733?w=400&h=200&fit=crop';
     document.getElementById('modalMenuName').textContent = menuName;
     document.getElementById('modalMenuIntro').textContent = menuIntro;
     document.getElementById('modalMenuPrice').textContent = formatPrice(menuPrice);
-    
+
     // 수량 초기화
     document.getElementById('quantityValue').textContent = '1';
     updateDecreaseButtonState();
-    
+
     // 모든 옵션 그룹 숨기기
     const allOptionGroups = document.querySelectorAll('.option-group');
     allOptionGroups.forEach(group => {
         group.style.display = 'none';
     });
-    
+
     // 기존 동적 옵션 제거
     const dynamicOptions = document.querySelectorAll('.dynamic-option-group');
     dynamicOptions.forEach(option => option.remove());
-    
+
     // 현재 옵션 상태 초기화
     currentMenuData.options = {};
-    
+
     // menu_extra 데이터가 있으면 동적으로 옵션 생성
     if (menuExtra && menuExtra.trim() && menuExtra !== 'null' && menuExtra !== '{}') {
         try {
@@ -557,10 +542,10 @@ function openMenuDetail(menuId, menuName, menuIntro, menuPrice, menuImage, menuE
             console.warn('menu_extra JSON 파싱 실패:', e);
         }
     }
-    
+
     // 총 가격 계산 및 표시
     calculateTotalPrice();
-    
+
     // 모달 표시
     const modal = document.getElementById('menuDetailModal');
     modal.style.display = 'flex';
@@ -569,78 +554,152 @@ function openMenuDetail(menuId, menuName, menuIntro, menuPrice, menuImage, menuE
 
 /**
  * menu_extra 데이터를 기반으로 동적 옵션 생성
- * @param {Object} extraData - menu_extra JSON 데이터
+ * @param {Array} extraData - menu_extra JSON 데이터 (새로운 형식)
  */
 function createDynamicOptions(extraData) {
     const optionsContainer = document.querySelector('.options-section');
-    if (!optionsContainer || !extraData.options) {
+    if (!optionsContainer || !Array.isArray(extraData)) {
         return;
     }
-    
-    extraData.options.forEach((option, index) => {
+
+    extraData.forEach((group, groupIndex) => {
         const optionGroup = document.createElement('div');
         optionGroup.className = 'option-group dynamic-option-group';
         optionGroup.style.display = 'block';
-        
+
         const optionTitle = document.createElement('h4');
         optionTitle.className = 'option-title';
-        optionTitle.textContent = option.name;
-        
+        optionTitle.textContent = group.groupName;
+
+        // 필수 여부 표시
+        if (group.required) {
+            const requiredBadge = document.createElement('span');
+            requiredBadge.className = 'required-badge';
+            requiredBadge.textContent = '필수';
+            requiredBadge.style.cssText = 'background: #ef4444; color: white; padding: 2px 6px; border-radius: 3px; font-size: 0.7rem; margin-left: 8px;';
+            optionTitle.appendChild(requiredBadge);
+        }
+
         const optionItems = document.createElement('div');
         optionItems.className = 'option-items';
-        
-        if (option.choices && option.choices.length > 0) {
-            option.choices.forEach((choice, choiceIndex) => {
+
+        if (group.options && group.options.length > 0) {
+            // 라디오 버튼 또는 체크박스 선택
+            const inputType = group.maxSelect === 1 ? 'radio' : 'checkbox';
+            const inputName = `dynamic_${groupIndex}`;
+
+            group.options.forEach((option, optionIndex) => {
                 const label = document.createElement('label');
                 label.className = 'option-item';
-                
+
                 const input = document.createElement('input');
-                input.type = 'radio';
-                input.name = `dynamic_${index}`;
-                input.value = choice.value;
-                input.dataset.price = choice.price || 0;
-                input.dataset.optionName = option.name;
-                if (choiceIndex === 0) input.checked = true; // 첫 번째 옵션 기본 선택
-                
+                input.type = inputType;
+                input.name = inputName;
+                input.value = option.name;
+                input.dataset.price = option.price || 0;
+                input.dataset.optionName = group.groupName;
+                input.dataset.maxSelect = group.maxSelect;
+
+                // 라디오 버튼인 경우 첫 번째 옵션 기본 선택
+                if (inputType === 'radio' && optionIndex === 0) {
+                    input.checked = true;
+                }
+
                 const optionText = document.createElement('span');
                 optionText.className = 'option-text';
-                optionText.textContent = choice.value;
-                
+                optionText.textContent = option.name;
+
                 const optionPrice = document.createElement('span');
                 optionPrice.className = 'option-price';
-                optionPrice.textContent = `+${(choice.price || 0).toLocaleString()}원`;
-                
+                optionPrice.textContent = `+${(option.price || 0).toLocaleString()}원`;
+
                 // 옵션 변경 이벤트 리스너
                 input.addEventListener('change', function() {
-                    currentMenuData.options[option.name] = {
-                        value: this.value,
-                        price: parseInt(this.dataset.price) || 0
-                    };
+                    handleOptionChange(group, this);
                     calculateTotalPrice();
                 });
-                
+
                 label.appendChild(input);
                 label.appendChild(optionText);
                 label.appendChild(optionPrice);
                 optionItems.appendChild(label);
-                
-                // 기본값 설정
-                if (choiceIndex === 0) {
-                    currentMenuData.options[option.name] = {
-                        value: choice.value,
-                        price: parseInt(choice.price) || 0
-                    };
+
+                // 기본값 설정 (라디오 버튼인 경우)
+                if (inputType === 'radio' && optionIndex === 0) {
+                    if (!currentMenuData.options[group.groupName]) {
+                        currentMenuData.options[group.groupName] = [];
+                    }
+                    currentMenuData.options[group.groupName] = [{
+                        name: option.name,
+                        price: parseInt(option.price) || 0
+                    }];
                 }
             });
         }
-        
+
         optionGroup.appendChild(optionTitle);
         optionGroup.appendChild(optionItems);
         optionsContainer.appendChild(optionGroup);
     });
 }
 
+/**
+ * 옵션 변경 처리
+ * @param {Object} group - 옵션 그룹 정보
+ * @param {HTMLInputElement} input - 변경된 input 요소
+ */
+function handleOptionChange(group, input) {
+    const groupName = group.groupName;
+    const maxSelect = group.maxSelect;
 
+    if (!currentMenuData.options[groupName]) {
+        currentMenuData.options[groupName] = [];
+    }
+
+    if (input.type === 'radio') {
+        // 라디오 버튼: 단일 선택
+        const optionPrice = parseInt(input.dataset.price) || 0;
+        currentMenuData.options[groupName] = [{
+            name: input.value,
+            price: optionPrice
+        }];
+    } else {
+        // 체크박스: 다중 선택
+        const selectedOptions = currentMenuData.options[groupName];
+
+        if (input.checked) {
+            // 선택된 경우
+            if (selectedOptions.length < maxSelect) {
+                const optionPrice = parseInt(input.dataset.price) || 0;
+                selectedOptions.push({
+                    name: input.value,
+                    price: optionPrice
+                });
+            } else {
+                // 최대 선택 개수 초과 시 체크 해제
+                input.checked = false;
+                alert(`최대 ${maxSelect}개까지 선택할 수 있습니다.`);
+                return;
+            }
+        } else {
+            // 선택 해제된 경우
+            const index = selectedOptions.findIndex(opt => opt.name === input.value);
+            if (index > -1) {
+                const removedOption = selectedOptions.splice(index, 1)[0];
+            }
+        }
+
+        // 필수 선택인 경우 최소 1개는 선택되어야 함
+        if (group.required && selectedOptions.length === 0) {
+            input.checked = true;
+            const optionPrice = parseInt(input.dataset.price) || 0;
+            selectedOptions.push({
+                name: input.value,
+                price: optionPrice
+            });
+        }
+    }
+}
 
 /**
  * 메뉴 상세 모달 닫기
@@ -649,7 +708,7 @@ function closeMenuDetail() {
     const modal = document.getElementById('menuDetailModal');
     modal.style.display = 'none';
     document.body.style.overflow = 'auto'; // 백그라운드 스크롤 복원
-    
+
     // 데이터 초기화
     currentMenuData = {
         menuId: null,
@@ -701,16 +760,19 @@ function updateDecreaseButtonState() {
  */
 function calculateTotalPrice() {
     let totalPrice = currentMenuData.menuPrice;
-    
-    // 선택된 옵션들의 가격 추가 (라디오 버튼과 체크박스 모두 지원)
-    document.querySelectorAll('.option-group input:checked').forEach(input => {
-        const optionPrice = parseInt(input.dataset.price) || 0;
-        totalPrice += optionPrice;
+
+    // 선택된 옵션들의 가격 추가 (새로운 형식)
+    Object.values(currentMenuData.options).forEach(optionArray => {
+        if (Array.isArray(optionArray)) {
+            optionArray.forEach(option => {
+                totalPrice += option.price || 0;
+            });
+        }
     });
-    
+
     // 수량 곱하기
     totalPrice *= currentMenuData.quantity;
-    
+
     // 총 가격 표시
     document.getElementById('totalPrice').textContent = formatPrice(totalPrice);
 }
@@ -730,16 +792,19 @@ function formatPrice(price) {
  */
 function calculateItemTotalPrice() {
     let totalPrice = currentMenuData.menuPrice;
-    
-    // 선택된 옵션들의 가격 추가 (라디오 버튼과 체크박스 모두 지원)
-    document.querySelectorAll('.option-group input:checked').forEach(input => {
-        const optionPrice = parseInt(input.dataset.price) || 0;
-        totalPrice += optionPrice;
+
+    // 선택된 옵션들의 가격 추가 (새로운 형식)
+    Object.values(currentMenuData.options).forEach(optionArray => {
+        if (Array.isArray(optionArray)) {
+            optionArray.forEach(option => {
+                totalPrice += option.price || 0;
+            });
+        }
     });
-    
+
     // 수량 곱하기
     totalPrice *= currentMenuData.quantity;
-    
+
     return totalPrice;
 }
 
@@ -747,42 +812,44 @@ function calculateItemTotalPrice() {
  * 장바구니에 메뉴 추가
  */
 function addMenuToCart() {
-    // 선택된 옵션들을 서버 API에 맞는 형식으로 수집 (동적 옵션만)
+    // 선택된 옵션들을 서버 API에 맞는 형식으로 수집
     const selectedOptions = {};
-    
-    // 동적 옵션 수집 (menu_extra 기반)
-    document.querySelectorAll('.dynamic-option-group input:checked').forEach(input => {
-        const optionName = input.dataset.optionName;
-        if (optionName) {
-            selectedOptions[optionName] = input.value;
+
+    // 새로운 옵션 형식으로 수집 (서버 호환 형식)
+    Object.entries(currentMenuData.options).forEach(([groupName, options]) => {
+        if (Array.isArray(options) && options.length > 0) {
+            // 서버에서 기대하는 형식: {"사이즈": "대", "토핑": ["치즈", "계란"]}
+            if (options.length === 1) {
+                // 단일 선택인 경우
+                selectedOptions[groupName] = options[0].name;
+            } else {
+                // 다중 선택인 경우
+                selectedOptions[groupName] = options.map(option => option.name);
+            }
         }
     });
-    
-    console.log('🍽️ 장바구니에 추가할 옵션:', selectedOptions);
-    
+
     // 새로운 자동 옵션 계산 API 사용 (fetch API)
     const formData = new FormData();
     formData.append('menuId', currentMenuData.menuId);
     formData.append('quantity', currentMenuData.quantity);
     formData.append('selectedOptions', JSON.stringify(selectedOptions));
-    
-    fetch(contextPath + '/user/cart/add-with-options', {
+
+    fetch(UrlConstants.Builder.fullUrl('/user/cart/add-with-options'), {
         method: 'POST',
         body: formData
     })
     .then(response => response.json())
     .then(response => {
-        console.log('✅ 장바구니 추가 성공:', response);
-        
         if (response.result === 'success') {
             // 성공 피드백
             showCartAddedFeedback();
-            
+
             // 하단 카트 바 업데이트
             if (document.getElementById('bottomCartBar')) {
                 updateCartInfo(response.cartCount, response.totalAmount);
             }
-            
+
             // 모달 닫기
             closeMenuDetail();
         } else {
@@ -790,7 +857,6 @@ function addMenuToCart() {
         }
     })
     .catch(error => {
-        console.error('❌ 장바구니 추가 실패:', error);
         alert('장바구니 추가 중 오류가 발생했습니다.');
     });
 }
@@ -804,15 +870,15 @@ function updateCartInfo(cartCount, totalAmount) {
     // 하단 카트 바 업데이트
     const cartCountElement = document.querySelector('.cart-count');
     const cartTotalElement = document.querySelector('.cart-total');
-    
+
     if (cartCountElement) {
         cartCountElement.textContent = cartCount || 0;
     }
-    
+
     if (cartTotalElement && totalAmount !== undefined) {
         cartTotalElement.textContent = formatPrice(totalAmount);
     }
-    
+
     // 기존 fetchCartInfo 함수가 있다면 호출
     if (typeof fetchCartInfo === 'function') {
         setTimeout(() => fetchCartInfo(), 100);
@@ -841,12 +907,12 @@ function showCartAddedFeedback() {
     `;
     toast.textContent = '🛒 장바구니에 추가되었습니다!';
     document.body.appendChild(toast);
-    
+
     // 애니메이션
     setTimeout(() => {
         toast.style.opacity = '1';
     }, 10);
-    
+
     setTimeout(() => {
         toast.style.opacity = '0';
         setTimeout(() => {
@@ -861,10 +927,10 @@ function showCartAddedFeedback() {
  */
 function renderOptionGroups(optionGroups) {
     const optionsContainer = document.getElementById('optionsContainer');
-    
+
     optionGroups.forEach((group, groupIndex) => {
         if (!group.options || group.options.length === 0) return;
-        
+
         // 옵션 그룹 HTML 생성
         const groupElement = document.createElement('div');
         groupElement.className = 'option-group';
@@ -887,7 +953,7 @@ function renderOptionGroups(optionGroups) {
                 `).join('')}
             </div>
         `;
-        
+
         optionsContainer.appendChild(groupElement);
     });
 }
@@ -905,4 +971,4 @@ function initializeOptionListeners() {
 }
 
 // 옵션 리스너 초기화
-document.addEventListener('DOMContentLoaded', initializeOptionListeners); 
+document.addEventListener('DOMContentLoaded', initializeOptionListeners);

--- a/src/main/webapp/js/storedetail.js
+++ b/src/main/webapp/js/storedetail.js
@@ -24,6 +24,10 @@ const CONFIG = {
 let kakaoMapLoaded = false;
 let kakaoMapLoading = false;
 
+// 도보 시간 계산 관련 변수
+let currentPosition = null;
+let walkingTimeCalculated = false;
+
 /* ===========================
    카카오맵 관련 함수들
    =========================== */
@@ -201,38 +205,157 @@ function showMapError() {
 }
 
 /* ===========================
-   탭 및 UI 관련 함수들
+   도보 시간 계산 관련 함수들
    =========================== */
 
 /**
- * 카테고리 필터 초기화
+ * 현재 위치 가져오기
  */
-function initializeCategoryFilter() {
-    const categoryTabs = document.querySelectorAll('.category-tab');
-    const menuItems = document.querySelectorAll('.menu-item');
-    
-    if (categoryTabs.length === 0 || menuItems.length === 0) return;
-    
-    categoryTabs.forEach(tab => {
-        tab.addEventListener('click', () => {
-            // 모든 탭에서 active 클래스 제거
-            categoryTabs.forEach(t => t.classList.remove('active'));
-            // 클릭된 탭에 active 클래스 추가
-            tab.classList.add('active');
-            
-            const category = tab.getAttribute('data-category');
-            
-            // 메뉴 항목 필터링
-            menuItems.forEach(item => {
-                if (category === '전체' || item.getAttribute('data-category') === category) {
-                    item.classList.remove('hidden');
-                } else {
-                    item.classList.add('hidden');
-                }
-            });
-        });
+function getCurrentPosition() {
+    return new Promise((resolve, reject) => {
+        if (!navigator.geolocation) {
+            reject(new Error('Geolocation is not supported'));
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                currentPosition = {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude
+                };
+                resolve(currentPosition);
+            },
+            (error) => {
+                console.error('위치 정보를 가져올 수 없습니다:', error);
+                reject(error);
+            },
+            {
+                enableHighAccuracy: true,
+                timeout: 10000,
+                maximumAge: 60000
+            }
+        );
     });
 }
+
+/**
+ * 도보 시간 계산
+ */
+function calculateWalkingTime() {
+    if (walkingTimeCalculated) return;
+    
+    const walkingTimeInfo = document.getElementById('walkingTimeInfo');
+    if (!walkingTimeInfo) return;
+
+    // 로딩 상태 표시
+    walkingTimeInfo.innerHTML = `
+        <div class="walking-time-loading">
+            <div class="spinner"></div>
+            <span>도보 시간 계산 중...</span>
+        </div>
+    `;
+
+    // 위치 권한 확인
+    if (!navigator.geolocation) {
+        walkingTimeInfo.innerHTML = `
+            <div class="walking-time-result" style="background: #f8f9fa; color: #666;">
+                <i>❓</i>
+                <span>위치 서비스 미지원</span>
+            </div>
+        `;
+        walkingTimeCalculated = true;
+        return;
+    }
+
+    getCurrentPosition()
+        .then((position) => {
+            const storeData = getStoreDataFromPage();
+            
+            // 거리 계산 및 도보 시간 추정
+            const distance = calculateDistance(position.lat, position.lng, storeData.latitude, storeData.longitude);
+            const estimatedTime = Math.round(distance * 20); // 1km당 20분으로 추정 (도보 속도 약 3km/h)
+            
+            // 거리에 따른 정확도 조정
+            let timeText = '';
+            if (distance < 0.1) {
+                timeText = '도보 1-2분';
+            } else if (distance < 0.5) {
+                timeText = `도보 약 ${estimatedTime}분`;
+            } else if (distance < 1) {
+                timeText = `도보 약 ${estimatedTime}분`;
+            } else {
+                timeText = `도보 약 ${estimatedTime}분 (${distance.toFixed(1)}km)`;
+            }
+            
+            walkingTimeInfo.innerHTML = `
+                <div class="walking-time-result">
+                    <i>🚶‍♂️</i>
+                    <span>${timeText}</span>
+                </div>
+            `;
+            walkingTimeCalculated = true;
+        })
+        .catch((error) => {
+            console.error('도보 시간 계산 실패:', error);
+            
+            let errorMessage = '위치 정보 없음';
+            if (error.code === 1) {
+                errorMessage = '위치 권한 거부됨';
+            } else if (error.code === 2) {
+                errorMessage = '위치 정보 없음';
+            } else if (error.code === 3) {
+                errorMessage = '위치 요청 시간 초과';
+            }
+            
+            walkingTimeInfo.innerHTML = `
+                <div class="walking-time-result" style="background: #f8f9fa; color: #666;">
+                    <i>❓</i>
+                    <span>${errorMessage}</span>
+                </div>
+            `;
+            walkingTimeCalculated = true;
+        });
+}
+
+/**
+ * 두 지점 간의 거리 계산 (Haversine 공식)
+ */
+function calculateDistance(lat1, lng1, lat2, lng2) {
+    const R = 6371; // 지구의 반지름 (km)
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLng = (lng2 - lng1) * Math.PI / 180;
+    const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
+              Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+              Math.sin(dLng/2) * Math.sin(dLng/2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+    const distance = R * c; // km
+    return distance;
+}
+
+/* ===========================
+   네비게이션 함수들
+   =========================== */
+
+/**
+ * 뒤로 가기
+ */
+function goBack() {
+    window.location.href = UrlConstants.Builder.fullUrl(UrlConstants.Pages.STORE_LIST);
+}
+
+/**
+ * 장바구니로 이동
+ */
+function goToCart() {
+    window.location.href = UrlConstants.Builder.fullUrl(UrlConstants.Pages.CART);
+}
+
+/* ===========================
+   탭 및 UI 관련 함수들
+   =========================== */
+
+
 
 /**
  * 별점 막대 그래프 초기화
@@ -317,9 +440,13 @@ function handleHeaderChange(tabName) {
         }
     }
     
-    // 지도 탭일 때 지도 초기화
+    // 상세정보 탭일 때 지도 초기화 및 도보 시간 계산
     if (tabName === 'map') {
-        setTimeout(loadKakaoMap, 300);
+        setTimeout(() => {
+            loadKakaoMap();
+            // 도보 시간 계산 (지도 로딩 후 약간의 지연을 두고 실행)
+            setTimeout(calculateWalkingTime, 1000);
+        }, 300);
     }
 }
 
@@ -378,9 +505,6 @@ function initializeStoreDetailPage() {
     // 탭 이벤트 초기화
     initializeTabEvents();
     
-    // 카테고리 필터 초기화
-    initializeCategoryFilter();
-    
     // 별점 막대 그래프 초기화
     initializeStarBars();
     
@@ -398,7 +522,7 @@ function initializeStoreDetailPage() {
         } else if (typeof updateCartBadge === 'function') {
             // 하단 카트 바가 없는 경우 개수만 조회
             console.log('🏷️ 배지만 초기화');
-            fetch(UrlConstants.Builder.fullUrl('/user/cart/count'))
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_COUNT))
                 .then(response => response.json())
                 .then(data => updateCartBadge(data.count || 0))
                 .catch(error => console.error('장바구니 개수 로드 실패:', error));
@@ -428,7 +552,7 @@ function loadStoreDetail() {
         return;
     }
     
-    fetch(UrlConstants.Builder.fullUrl('/user/store/api/detail/' + storeId))
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.STORE_DETAIL + '/' + storeId))
         .then(response => response.json())
         .then(data => {
             if (data.success) {
@@ -445,7 +569,7 @@ function loadStoreDetail() {
 }
 
 function loadReviews(storeId) {
-    fetch(UrlConstants.Builder.fullUrl(`/user/review/api/list?storeId=${storeId}`))
+            fetch(UrlConstants.Builder.fullUrl(`${UrlConstants.API.REVIEW_LIST}?storeId=${storeId}`))
         .then(response => response.json())
         .then(data => {
             if (data.success) {
@@ -835,7 +959,7 @@ function addMenuToCart() {
     formData.append('quantity', currentMenuData.quantity);
     formData.append('selectedOptions', JSON.stringify(selectedOptions));
 
-    fetch(UrlConstants.Builder.fullUrl('/user/cart/add-with-options'), {
+            fetch(UrlConstants.Builder.fullUrl(UrlConstants.API.CART_ADD_WITH_OPTIONS), {
         method: 'POST',
         body: formData
     })

--- a/src/main/webapp/js/urlConstants.js
+++ b/src/main/webapp/js/urlConstants.js
@@ -1,5 +1,5 @@
 /**
- * 클라이언트 사이드에서 사용할 URL 상수 객체 (단순화된 버전)
+ * 클라이언트 사이드에서 사용할 URL 상수 객체
  */
 window.UrlConstants = {
     
@@ -41,7 +41,7 @@ window.UrlConstants = {
          * 가게 상세 페이지 URL 생성
          */
         storeDetail: function(storeId) {
-            const path = `/user/store/detail?storeId=${storeId}`;
+            const path = `${UrlConstants.Pages.STORE_DETAIL}?storeId=${storeId}`;
             return window.UrlConstants.Builder.fullUrl(path);
         },
         
@@ -49,9 +49,61 @@ window.UrlConstants = {
          * 찜 추가/취소 URL 생성
          */
         likeAction: function(isAdd) {
-            const path = isAdd ? '/user/like/add' : '/user/like/cancel';
+            const path = isAdd ? UrlConstants.API.LIKE_ADD : UrlConstants.API.LIKE_CANCEL;
             return window.UrlConstants.Builder.fullUrl(path);
         }
+    },
+    
+    /**
+     * 주요 페이지 URL들
+     */
+    Pages: {
+        STORE_LIST: '/user/store',
+        STORE_DETAIL: '/user/store/detail',
+        CART: '/user/cart',
+        CART_PAYMENT_METHOD: '/user/cart/payment-method',
+        CART_INVITE_FRIENDS: '/user/cart/invite-friends',
+        CART_MAKE_BILL: '/user/cart/make-bill',
+        CART_WAITING_APPROVAL: '/user/cart/waiting-approval',
+        CART_PAYMENT_COMPLETE: '/user/cart/payment-complete',
+        MY_PAGE: '/user/mypage',
+        LIKE: '/user/like'
+    },
+    
+    /**
+     * API 엔드포인트들
+     */
+    API: {
+        // 가게 관련
+        STORE_LIST: '/user/store/api/list',
+        STORE_SEARCH: '/user/store/api/search',
+        STORE_DETAIL: '/user/store/api/detail',
+        STORE_CATEGORY_CONFIG: '/user/store/api/category/config',
+        STORE_SEARCH_BY_NAME: '/user/store/search/name',
+        
+        // 장바구니 관련
+        CART_COUNT: '/user/cart/count',
+        CART_ADD: '/user/cart/add',
+        CART_ADD_WITH_OPTIONS: '/user/cart/add-with-options',
+        CART_UPDATE: '/user/cart/update',
+        CART_REMOVE: '/user/cart/remove',
+        CART_CLEAR: '/user/cart/clear',
+        CART_TOTAL: '/user/cart/total',
+        CART_SELECTED_FRIENDS: '/user/cart/selected-friends',
+        CART_FRIENDS_API: '/user/cart/friends-api',
+        CART_FRIENDS_SYNC: '/user/cart/friends/sync',
+        CART_INVITE_CONFIRM: '/user/cart/invite-confirm',
+        CART_GET_SELECTED_FRIENDS: '/user/cart/get-selected-friends',
+        CART_CALCULATE_DUTCH_PAY: '/user/cart/calculate-dutch-pay',
+        CART_SUBMIT_BILL: '/user/cart/submit-bill',
+        CART_PAYMENT_STATUS_STREAM: '/user/cart/payment-status-stream',
+        
+        // 리뷰 관련
+        REVIEW_LIST: '/user/review/api/list',
+        
+        // 찜 관련
+        LIKE_ADD: '/user/like/add',
+        LIKE_CANCEL: '/user/like/cancel'
     }
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

1. Owner 관리페이지에서 메뉴 옵션을 추가하는 방식대로 장바구니 로직을 변경했습니다.
2. store 지도 탭에서 가게 마커 클릭 후 가게 상세정보 클릭 시 우리가 정보를 가지고 있지 않은 가게의 경우에는 카카오맵으로 이동할 수 있도록 모달 창 띄움
3. 메뉴 카테고리 부분 모두 삭제
4. store 상세페이지 상세정보 탭 개선

### 스크린샷 (선택)

<img width="472" alt="image" src="https://github.com/user-attachments/assets/67e2d4bb-b603-4f23-8107-55f83005a649" />
<img width="314" alt="image" src="https://github.com/user-attachments/assets/d30dd815-d263-446d-a027-8dbbeb1fd809" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/ee4f6a27-35b5-4607-8053-6c58c6cd9b9b" />



## 💬리뷰 요구사항(선택)

> 