### PR TITLE
Feat: 결제 테이블 통합, 자세히 보기 구현, 리드미 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🍽️ Sol-Food - 홍대 맛집 리뷰 플랫폼
+# 🍽️ Sol-Food - 홍대 주변 맛집 리뷰 플랫폼
 
 <div align="center">
 
@@ -38,7 +38,7 @@
 
 ## 📖 프로젝트 개요
 
-**Sol-Food**는 홍대입구역 주변의 다양한 맛집 정보를 제공하고, 사용자들이 직접 리뷰를 작성하고 공유할 수 있는 웹 플랫폼입니다. 카카오 Local API를 활용한 자동 데이터 수집과 사용자 참여형 리뷰 시스템을 통해 신뢰할 수 있는 맛집 정보를 제공합니다.
+Sol-Food는 홍대입구역 **주변**의 다양한 맛집 정보를 제공하고, 사용자들이 직접 리뷰를 작성하고 공유할 수 있는 웹 플랫폼입니다. 카카오 Local API를 활용한 자동 데이터 수집, 사용자 참여형 리뷰 시스템, 강력한 관리자/점주/사용자 권한 분리, 결제 관리 등 실전 서비스 수준의 기능을 제공합니다.
 
 ### 🎯 주요 특징
 
@@ -119,162 +119,160 @@
 - **사용자 관리**: 회원 정보 조회 및 관리
 - **가게 크롤링**: 카카오 API를 통한 자동 가게 정보 수집
 - **통계 대시보드**: 사용자 활동 및 가게 통계 확인
+- **결제 관리**: 통합결제 내역 조회 및 상세 페이지
 
 ---
 
-## 🏗️ 아키텍처
+## 📁 폴더/모듈 구조 및 역할
 
 ```
-Sol-Food/
-├── 📁 src/main/java/kr/co/solfood/
-│   ├── 👤 user/           # 일반 사용자 기능
-│   │   ├── login/         # 로그인/회원가입
-│   │   ├── store/         # 맛집 정보
-│   │   ├── review/        # 리뷰 시스템
-│   │   ├── menu/          # 메뉴 관리
-│   │   └── mypage/        # 마이페이지
-│   ├── 🏪 owner/          # 점주 기능
-│   │   └── login/         # 점주 로그인
-│   ├── 👨‍💼 admin/         # 관리자 기능
-│   │   ├── home/          # 관리자 홈
-│   │   ├── crawler/       # 웹 크롤링
-│   │   └── dto/           # 데이터 전송 객체
-│   └── ⚙️ configuration/  # 설정 클래스
-├── 📁 src/main/resources/
-│   ├── 📄 kr/co/solfood/  # MyBatis 매퍼 XML
-│   └── 📄 webapp/         # JSP 뷰 파일
-└── 📁 src/test/           # 테스트 코드
-```
+src/main/java/kr/co/solfood/
+├── user/      # 일반 사용자(로그인, 게시판, 마이페이지, 리뷰, 카트, 가게, 메뉴, 좋아요, 게임, 카테고리 등)
+├── owner/     # 점주(로그인, 가게, 리뷰, 메뉴)
+├── admin/     # 관리자(홈, 로그인, 크롤러, DTO, 결제관리 등)
+├── payments/  # 결제(통합결제, 단일결제, 공통, 충전 등)
+├── common/    # 공통 상수, S3 등
+├── util/      # 예외, 페이징, 에러코드 등 유틸리티
 
-### 🔄 데이터 흐름
+src/main/resources/kr/co/solfood/
+├── user/      # 사용자 매퍼(Board, Login, Store, Review, Mypage 등)
+├── owner/     # 점주 매퍼
+├── admin/     # 관리자 매퍼(Home, Login)
+├── payments/  # 결제 매퍼(Payment, Integrated, Charge)
 
-```
-사용자 요청 → Controller → Service → Mapper → Database
-                ↓
-            View(JSP) ← Model ← Service ← Mapper
-```
+src/main/webapp/WEB-INF/views/
+├── user/      # 사용자 JSP(로그인, 게시판, 가게, 마이페이지, 리뷰, 카트, 게임 등)
+├── owner/     # 점주 JSP(가게, 메뉴, 리뷰, 매출 등)
+├── admin/     # 관리자 JSP(홈, 사용자/점주/결제/리뷰 관리, 로그인 등)
+│   └── payment-management/ (home.jsp, detail.jsp)
+├── common/    # 공통 헤더 등
 
----
+src/main/webapp/js/admin/
+├── payment-management.js  # 결제관리 JS
+├── user-management.js     # 사용자관리 JS
+├── owner-management.js    # 점주관리 JS
 
-## 🛠️ 기술 스택
+src/main/webapp/css/admin/
+├── payment-management.css  # 결제관리 CSS
+├── user-management.css     # 사용자관리 CSS
+├── owner-management.css    # 점주관리 CSS
 
-### 🎯 Backend
-- **Java 11**: 메인 프로그래밍 언어
-- **Spring Framework 5.2.25**: 웹 애플리케이션 프레임워크
-- **Spring MVC**: 웹 MVC 패턴 구현
-- **MyBatis 3.5.19**: ORM 프레임워크
-- **HikariCP 6.3.0**: 데이터베이스 커넥션 풀
-
-### 🗄️ Database
-- **Oracle Database 19c**: 메인 데이터베이스
-- **MariaDB 3.5.3**: 대체 데이터베이스 지원
-- **log4jdbc**: SQL 로깅
-
-### 🌐 Frontend
-- **JSP**: 서버 사이드 뷰 템플릿
-- **JSTL**: JSP 표준 태그 라이브러리
-- **Kakao Maps API**: 지도 및 위치 서비스
-- **Bootstrap**: 반응형 UI 프레임워크
-
-### 🔧 개발 도구
-- **Maven**: 빌드 및 의존성 관리
-- **Lombok**: 보일러플레이트 코드 제거
-- **JUnit 5**: 단위 테스트
-- **Mockito**: 모킹 프레임워크
-
-### 📡 외부 API
-- **Kakao Local API**: 맛집 정보 수집
-- **Kakao Maps JavaScript API**: 지도 서비스
-
----
-
-## 📊 주요 기능 상세
-
-### 🗺️ 맛집 검색 시스템
-```java
-@GetMapping("/user/store")
-public String getStoreList(@RequestParam String category, Model model) {
-   List<StoreVO> storeList = service.getCategoryStore(category);
-   model.addAttribute("store", storeList);
-   return "user/store";
-}
-```
-
-### ⭐ 리뷰 시스템
-- **별점 평가**: 1~5점 별점 시스템
-- **리뷰 작성**: 제목, 내용, 별점, 사진 업로드
-- **통계 제공**: 평균 별점, 별점별 개수 통계
-
-### 🤖 자동 크롤링
-```java
-@Component
-public class StoreWebCrawler {
-   public List<StoreVO> crawlHongdaeRestaurants() {
-      // 카카오 Local API를 통한 홍대 맛집 정보 수집
-   }
-}
 ```
 
 ---
 
-## 🧪 테스트
+## 🏗️ 아키텍처 및 데이터 흐름
 
-### 단위 테스트 실행
-```bash
-mvn test
+```
+사용자/관리자 요청
+  ↓
+Controller (ex: AdminHomeController)
+  ↓
+Service (ex: AdminHomeService)
+  ↓
+Mapper (MyBatis, ex: AdminMapper.xml, PaymentMapper.xml 등)
+  ↓
+DB
+  ↑
+Model(DTO) → JSP View (ex: payment-management/detail.jsp)
 ```
 
-### 주요 테스트 케이스
-- `LoginServiceImplTest`: 로그인 서비스 테스트
-- `ExceptionTest`: 예외 처리 테스트
-- `AdminTest`: 관리자 기능 테스트
+- **결제 상세**: PageMaker<PaymentDistinctResponseDto>로 여러 결제 정보 리스트 전달
+- JSP에서 forEach로 반복, 각 인원별 상세를 아코디언+카드로 출력
+- DTO의 날짜 필드는 LocalDateTime → JSP에서 문자열로 출력
+- 매퍼 XML은 src/main/resources/kr/co/solfood/ 하위에 기능별로 분리
 
 ---
 
-## 📈 성능 최적화
+## 🌟 결제관리 상세 페이지 (관리자)
 
-### 🚀 성능 개선 사항
-- **HikariCP**: 고성능 커넥션 풀 사용
-- **MyBatis**: 효율적인 SQL 매핑
-- **캐싱**: 자주 조회되는 데이터 캐싱
-- **인덱싱**: 데이터베이스 인덱스 최적화
+- **경로**: `/admin/payment-management/detail?integratedpaymentId=...`
+- **기능**:
+  - 통합결제ID로 여러 인원의 결제 내역을 한 번에 조회
+  - 각 인원의 결제 상세를 아코디언(토글)으로 펼쳐서 확인
+  - 결제 정보(금액, 상태, 수단 등), 결제자 정보, 사용자 정보(프로필 포함) 등 섹션별 카드로 구분
+  - Bootstrap 5 적용, 반응형/컬러/아이콘/뱃지 등 시각적 강조
+  - 영수증 바로가기, 결제 취소 등 액션 버튼
+  - 에러 발생 시 사용자 친화적 안내
+
+#### 📄 JSP 구조 예시
+```jsp
+<div class="accordion" id="paymentAccordion">
+  <c:forEach var="detail" items="${paymentDetail.list}" varStatus="status">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="heading${status.index}">
+        <button class="accordion-button collapsed" ...>
+          <span class="me-2">💳</span> <b>${detail.usersName}</b> <span class="text-muted">/ 결제ID: ${detail.paymentId}</span>
+        </button>
+      </h2>
+      <div id="collapse${status.index}" ...>
+        <div class="accordion-body">
+          <div class="row g-4">
+            <div class="col-md-6"> ...결제 정보 카드... </div>
+            <div class="col-md-6"> ...결제자 정보 카드... </div>
+          </div>
+          <hr/>
+          <div class="row g-4">
+            <div class="col-md-12"> ...사용자 정보 카드... </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </c:forEach>
+</div>
+```
+
+#### 🛠️ 기술 포인트
+- Bootstrap 5 CDN 적용 (CSS/JS)
+- JSTL forEach, 조건문, 뱃지/아이콘/컬러 등 적극 활용
+- DTO의 LocalDateTime은 JSP에서 문자열로 출력 (formatDate 사용 X)
+- 컨트롤러에서 PageMaker로 리스트 전달, JSP에서 반복문으로 출력
+- 에러 발생 시 500 에러 안내 및 원인(날짜 타입 등) 명확히 처리
 
 ---
 
-## 🔒 보안
+## 🛠️ 사용 기술/라이브러리
 
-### 🔐 보안 기능
-- **인터셉터**: 로그인 상태 검증
-- **세션 관리**: 안전한 세션 처리
-- **SQL 인젝션 방지**: MyBatis 파라미터 바인딩
-- **XSS 방지**: 입력 데이터 검증
+### Backend
+- Java 11, Spring Framework 5.2.25, Spring MVC, MyBatis 3.5.19, HikariCP 6.3.0
+- Lombok, JUnit5, Mockito, log4jdbc
 
----
+### Database
+- Oracle 19c, MariaDB 3.5.3
 
-## 🤝 기여하기
+### Frontend
+- JSP, JSTL, Bootstrap 5, Kakao Maps API, jQuery(일부), CSS/JS 분리
 
-1. **Fork** the Project
-2. **Create** your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. **Commit** your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. **Push** to the Branch (`git push origin feature/AmazingFeature`)
-5. **Open** a Pull Request
+### 외부 API
+- Kakao Local API, Kakao Maps JavaScript API
 
----
-
-## 📝 라이선스
-
-이 프로젝트는 **MIT 라이선스** 하에 배포됩니다. 자세한 내용은 [LICENSE](LICENSE) 파일을 참조하세요.
+### 기타
+- S3 파일 업로드, 페이징 유틸, 커스텀 예외/에러코드, 세션/인터셉터 보안 등
 
 ---
 
-## 📞 문의
-
-- **이메일**: contact@sol-food.com
-- **이슈 트래커**: [GitHub Issues](https://github.com/your-username/sol-food/issues)
-- **문서**: [Wiki](https://github.com/your-username/sol-food/wiki)
+## 🧩 DTO/매퍼/컨트롤러/뷰 연동
+- DTO는 기능별로 src/main/java/kr/co/solfood/*/dto/에 위치
+- 매퍼 XML은 src/main/resources/kr/co/solfood/*/에 위치, 기능별로 분리
+- 컨트롤러는 각 도메인별로 분리, Model에 DTO/리스트/페이징 객체 전달
+- JSP는 forEach, 조건문, Bootstrap 카드/아코디언 등으로 데이터 시각화
+- JS/CSS는 기능별로 분리, 관리자 결제관리 전용 payment-management.js/css 존재
 
 ---
 
-**🍽️ Sol-Food와 함께 맛있는 홍대 맛집을 발견하세요!**
+## 🛡️ 에러 처리/보안
+- LocalDateTime 등 날짜 타입은 JSP에서 문자열로 출력, formatDate 사용 시 500에러 주의
+- CustomException, ErrorCode, ErrorResponseEntity 등으로 예외/에러 일관 처리
+- 세션/인터셉터로 관리자/점주/사용자 권한 분리 및 인증
+- SQL 인젝션 방지, XSS 방지, 입력 검증 등 보안 적용
 
-[⬆️ 맨 위로](#-sol-food---홍대-맛집-리뷰-플랫폼)
+---
+
+## 🧪 테스트/기여/문의
+- JUnit5, Mockito 기반 단위/통합 테스트
+- 테스트 코드 src/test/java/kr/co/solfood/ 하위에 위치
+- 기여: Fork & PR, 이슈/문의는 GitHub Issues 또는 contact@sol-food.com
+
+---
+
+**🍽️ Sol-Food와 함께 홍대 주변 맛집을 발견하고, 강력한 관리자 결제 관리 기능으로 운영 효율을 높이세요!**

--- a/src/main/java/kr/co/solfood/admin/dto/PaymentDistinctRequestDto.java
+++ b/src/main/java/kr/co/solfood/admin/dto/PaymentDistinctRequestDto.java
@@ -1,0 +1,12 @@
+package kr.co.solfood.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import kr.co.solfood.util.PageDTO;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class PaymentDistinctRequestDto extends PageDTO {
+    private String integratedpaymentId; // 통합 결제 아이디
+}

--- a/src/main/java/kr/co/solfood/admin/dto/PaymentDistinctResponseDto.java
+++ b/src/main/java/kr/co/solfood/admin/dto/PaymentDistinctResponseDto.java
@@ -1,0 +1,46 @@
+package kr.co.solfood.admin.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class PaymentDistinctResponseDto {
+    // payment 테이블
+    private Long paymentId;
+    private Long usersId;
+    private Long integratedpaymentId;
+    private Integer paymentUsedPoint;
+    private Integer paymentPaidAmount;
+    private String paymentImpUid;
+    private String paymentMerchantUid;
+    private String paymentMethod;
+    private String paymentPgProvider;
+    private String paymentPgTid;
+    private String paymentReceiptUrl;
+    private String paymentStatus;
+    private String paymentStatusDetail;
+    private Integer paymentAmount;
+    private Integer paymentCancelAmount;
+    private String paymentBuyerName;
+    private String paymentBuyerEmail;
+    private String paymentBuyerTel;
+    private String paymentFailReason;
+    private String paymentCancelReason;
+    private LocalDateTime paymentPaidAt;
+    private LocalDateTime paymentCancelledAt;
+    private LocalDateTime paymentCreatedAt;
+    private LocalDateTime paymentUpdatedAt;
+
+    // users 테이블
+    private String usersName;
+    private String usersNickname;
+    private String usersEmail;
+    private String usersProfile;
+    private Integer usersPoint;
+    private String usersGender;
+    private String usersLoginType;
+    private String usersTel;
+    private String usersStatus;
+    private String usersRejectedReason;
+}

--- a/src/main/java/kr/co/solfood/admin/dto/PaymentSearchResponseDto.java
+++ b/src/main/java/kr/co/solfood/admin/dto/PaymentSearchResponseDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Data
 public class PaymentSearchResponseDto {
+    private String integratedpaymentId; // 통합 결제 아이디
     private String paymentId; // 결제 아이디
     private String usersName; // 결제한 유저 이름
     private long paymentPaidAmount; // 금액

--- a/src/main/java/kr/co/solfood/admin/home/AdminHomeController.java
+++ b/src/main/java/kr/co/solfood/admin/home/AdminHomeController.java
@@ -10,10 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -263,7 +260,6 @@ public class AdminHomeController {
         }
     }
 
-
     @GetMapping("/payment-management/search")
     @ResponseBody
     public PageMaker<PaymentSearchResponseDto> getPayments(PaymentSearchRequestDto paymentSearchRequestDto, Model model) {
@@ -276,4 +272,18 @@ public class AdminHomeController {
             return new PageMaker<>();
         }
     }
+
+    @GetMapping("/payment-management/detail")
+    public String paymentDetail(@RequestParam("integratedpaymentId") String integratedpaymentId, @ModelAttribute PaymentDistinctRequestDto paymentDistinctRequestDto, Model model) {
+        try {
+            PageMaker<PaymentDistinctResponseDto> paymentDetail = adminHomeService.getDistinctPayments(paymentDistinctRequestDto);
+            model.addAttribute("paymentDetail", paymentDetail);
+            log.info("Payment detail retrieved: {}", paymentDetail);
+        } catch (CustomException e) {
+            log.info("Payment detail retrieval failed: {}", e.getMessage());
+            model.addAttribute("error", e.getMessage());
+        }
+        return "admin/payment-management/detail";
+    }
+
 }

--- a/src/main/java/kr/co/solfood/admin/home/AdminHomeService.java
+++ b/src/main/java/kr/co/solfood/admin/home/AdminHomeService.java
@@ -25,4 +25,6 @@ public interface AdminHomeService {
     PageMaker<CommunityResponseDto> getCommunityResponses(CommunityRequestDto communityRequestDto);
 
     void deleteOwnerReview(long reviewId);
+
+    PageMaker<PaymentDistinctResponseDto> getDistinctPayments(PaymentDistinctRequestDto paymentDistinctRequestDto);
 }

--- a/src/main/java/kr/co/solfood/admin/home/AdminHomeServiceImpl.java
+++ b/src/main/java/kr/co/solfood/admin/home/AdminHomeServiceImpl.java
@@ -132,6 +132,17 @@ public class AdminHomeServiceImpl implements AdminHomeService {
     }
 
     @Override
+    public PageMaker<PaymentDistinctResponseDto> getDistinctPayments(PaymentDistinctRequestDto paymentDistinctRequestDto) {
+        List<PaymentDistinctResponseDto> paymentDistinctResponseDto = adminMapper.getDistinctPayments(paymentDistinctRequestDto);
+        int size = adminMapper.getDistinctPaymentsCount(paymentDistinctRequestDto);
+
+        if (paymentDistinctResponseDto == null) {
+            throw new CustomException(ErrorCode.UNDEFINED_SEARCH);
+        }
+        return new PageMaker<>(paymentDistinctResponseDto, size, paymentDistinctRequestDto.getPageSize(), paymentDistinctRequestDto.getCurrentPage());
+    }
+
+    @Override
     public PageMaker<PaymentSearchResponseDto> getPayments(PaymentSearchRequestDto paymentSearchRequestDto) {
         List<PaymentSearchResponseDto> paymentSearchResponseDto = adminMapper.getPayments(paymentSearchRequestDto);
         int size = adminMapper.getPaymentsCount(paymentSearchRequestDto);

--- a/src/main/java/kr/co/solfood/admin/home/AdminMapper.java
+++ b/src/main/java/kr/co/solfood/admin/home/AdminMapper.java
@@ -40,4 +40,8 @@ public interface AdminMapper {
     int getCommunityResponsesCount(CommunityRequestDto communityRequestDto);
 
     void deleteOwnerReview(long reviewId);
+
+    int getDistinctPaymentsCount(PaymentDistinctRequestDto paymentDistinctRequestDto);
+
+    List<PaymentDistinctResponseDto> getDistinctPayments(PaymentDistinctRequestDto paymentDistinctRequestDto);
 }

--- a/src/main/resources/kr/co/solfood/admin/home/AdminMapper.xml
+++ b/src/main/resources/kr/co/solfood/admin/home/AdminMapper.xml
@@ -221,8 +221,9 @@
         P.payment_receipt_url,
         P.payment_status,
         P.payment_created_at
-        FROM payment P, users U, integrated_payment I
-        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id
+        FROM payment P
+        JOIN users U ON P.users_id = U.users_id
+        JOIN integrated_payment I ON I.integratedpayment_id = P.integratedpayment_id
         <where>
             <if test="query != null and query != ''">
                 AND U.users_name LIKE CONCAT('%', #{query}, '%')
@@ -240,9 +241,10 @@
 
     <select id="getPaymentsCount" parameterType="kr.co.solfood.admin.dto.PaymentSearchRequestDto" resultType="int">
         SELECT COUNT(*)
-        FROM payment P, users U, integrated_payment I
-        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id
-        <where>
+        FROM payment P
+        JOIN users U ON P.users_id = U.users_id
+        JOIN integrated_payment I ON I.integratedpayment_id = P.integratedpayment_id
+            <where>
             <if test="query != null and query != ''">
                 AND U.users_name LIKE CONCAT('%', #{query}, '%')
             </if>

--- a/src/main/resources/kr/co/solfood/admin/home/AdminMapper.xml
+++ b/src/main/resources/kr/co/solfood/admin/home/AdminMapper.xml
@@ -212,7 +212,7 @@
     <select id="getPayments" parameterType="kr.co.solfood.admin.dto.PaymentSearchRequestDto"
             resultType="kr.co.solfood.admin.dto.PaymentSearchResponseDto">
         SELECT
-        P.payment_id,
+        I.integratedpayment_id,
         U.users_name,
         P.payment_paid_amount,
         P.payment_used_point,
@@ -221,11 +221,11 @@
         P.payment_receipt_url,
         P.payment_status,
         P.payment_created_at
-        FROM payment P
-        LEFT JOIN users U ON P.users_id = U.users_id
+        FROM payment P, users U, integrated_payment I
+        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id
         <where>
             <if test="query != null and query != ''">
-                U.users_name LIKE CONCAT('%', #{query}, '%')
+                AND U.users_name LIKE CONCAT('%', #{query}, '%')
             </if>
             <if test="fromDate != null and toDate != null">
                 AND P.payment_created_at BETWEEN #{fromDate} AND #{toDate}
@@ -240,11 +240,11 @@
 
     <select id="getPaymentsCount" parameterType="kr.co.solfood.admin.dto.PaymentSearchRequestDto" resultType="int">
         SELECT COUNT(*)
-        FROM payment P
-        JOIN users U ON P.users_id = U.users_id
+        FROM payment P, users U, integrated_payment I
+        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id
         <where>
             <if test="query != null and query != ''">
-                U.users_name LIKE CONCAT('%', #{query}, '%')
+                AND U.users_name LIKE CONCAT('%', #{query}, '%')
             </if>
             <if test="fromDate != null and toDate != null">
                 AND P.payment_created_at BETWEEN #{fromDate} AND #{toDate}
@@ -253,5 +253,17 @@
                 AND P.payment_status = #{paymentStatus}
             </if>
         </where>
+    </select>
+    
+    <select id="getDistinctPayments" parameterType="kr.co.solfood.admin.dto.PaymentDistinctRequestDto" resultType="kr.co.solfood.admin.dto.PaymentDistinctResponseDto">
+       SELECT *
+        FROM payment P, users U, integrated_payment I
+        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id AND  I.integratedpayment_id = #{integratedpaymentId}
+    </select>
+
+    <select id="getDistinctPaymentsCount" parameterType="kr.co.solfood.admin.dto.PaymentDistinctRequestDto" resultType="int">
+        SELECT COUNT(*)
+        FROM payment P, users U, integrated_payment I
+        WHERE I.integratedpayment_id = P.integratedpayment_id AND P.users_id = U.users_id AND  I.integratedpayment_id = #{integratedpaymentId}
     </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/payment-management/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/payment-management/detail.jsp
@@ -1,0 +1,309 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <title>관리 &gt; 결제 상세 정보</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Bootstrap 5 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/admin/payment-management.css">
+    <style>
+        .payment-id-badge {
+            background: #e3f2fd;
+            color: #1976d2;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+
+        .status-pending {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .detail-item {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background: #f8f9fa;
+            border-radius: 0.5rem;
+        }
+
+        .detail-label {
+            font-weight: 600;
+            color: #495057;
+            font-size: 0.875rem;
+            display: block;
+            margin-bottom: 0.25rem;
+        }
+
+        .detail-value {
+            font-size: 1rem;
+            color: #212529;
+            word-break: break-all;
+        }
+
+        .amount-text {
+            font-size: 1.125rem;
+            font-weight: 600;
+            color: #28a745;
+        }
+
+        .point-text {
+            font-size: 1.125rem;
+            font-weight: 600;
+            color: #fd7e14;
+        }
+
+        .payment-method-badge {
+            background: #d4edda;
+            color: #155724;
+            padding: 0.25rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .login-type-badge {
+            background: #cce5ff;
+            color: #0056b3;
+            padding: 0.25rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+
+        .user-profile-section {
+            text-align: center;
+            padding: 1rem;
+        }
+
+        .profile-image {
+            margin-bottom: 1rem;
+        }
+
+        .profile-img {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 3px solid #e9ecef;
+        }
+
+        .profile-placeholder {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #28a745, #20c997);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto;
+            color: white;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        .user-basic-info h5 {
+            margin: 0.5rem 0 0.25rem 0;
+            color: #212529;
+        }
+
+        .user-basic-info p {
+            margin: 0;
+            font-size: 0.875rem;
+        }
+
+        .receipt-section {
+            padding: 1rem;
+            background: #f8f9fa;
+            border-radius: 0.5rem;
+        }
+
+        .receipt-link {
+            margin-top: 0.5rem;
+        }
+
+        .action-buttons {
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+            margin-top: 2rem;
+            padding: 1rem;
+        }
+
+        .section-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #212529;
+            margin-bottom: 1.5rem;
+        }
+
+        @media (max-width: 768px) {
+            .action-buttons {
+                flex-direction: column;
+            }
+
+            .user-profile-section {
+                margin-bottom: 1rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+<div class="d-flex">
+    <!-- Sidebar -->
+    <nav class="side-menu">
+        <h4>🌿 관리자 메뉴</h4>
+        <a href="<c:url value="/admin/home"/>" class="nav-link">홈</a>
+        <a href="<c:url value="/admin/user-management"/>" class="nav-link">사용자</a>
+        <a href="<c:url value="/admin/owner-management"/>" class="nav-link">점주</a>
+        <a href="<c:url value="/admin/payment-management"/>" class="nav-link active">결제</a>
+        <a href="#" class="nav-link">정책</a>
+        <div class="mt-auto">
+            <small class="text-muted">© 2025 YourCompany</small>
+        </div>
+    </nav>
+
+    <!-- Main content -->
+    <div class="main flex-grow-1">
+        <!-- Breadcrumb -->
+        <nav aria-label="breadcrumb" class="mb-3">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="<c:url value="/admin/payment-management"/>">결제 관리</a></li>
+                <li class="breadcrumb-item active" aria-current="page">결제 상세 정보</li>
+            </ol>
+        </nav>
+
+        <!-- 아코디언으로 결제 정보 반복 -->
+        <div class="accordion" id="paymentAccordion">
+            <c:forEach var="detail" items="${paymentDetail.list}" varStatus="status">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="heading${status.index}">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse${status.index}" aria-expanded="false" aria-controls="collapse${status.index}">
+                            <span class="me-2">💳</span> <b>${detail.usersName}</b> <span class="text-muted">/ 결제ID: ${detail.paymentId}</span>
+                        </button>
+                    </h2>
+                    <div id="collapse${status.index}" class="accordion-collapse collapse" aria-labelledby="heading${status.index}" data-bs-parent="#paymentAccordion">
+                        <div class="accordion-body">
+                            <div class="row g-4">
+                                <!-- 결제 정보 -->
+                                <div class="col-md-6">
+                                    <div class="card h-100 shadow-sm">
+                                        <div class="card-header bg-success text-white"><b>결제 정보</b></div>
+                                        <div class="card-body">
+                                            <ul class="list-group list-group-flush">
+                                                <li class="list-group-item"><b>결제ID:</b> ${detail.paymentId}</li>
+                                                <li class="list-group-item"><b>통합 결제 ID:</b> ${detail.integratedpaymentId}</li>
+                                                <li class="list-group-item"><b>결제 금액:</b> <span class="text-success fw-bold">${detail.paymentAmount}원</span></li>
+                                                <li class="list-group-item"><b>실제 결제 금액:</b> <span class="text-success fw-bold">${detail.paymentPaidAmount}원</span></li>
+                                                <li class="list-group-item"><b>사용 포인트:</b> <span class="text-warning fw-bold">${detail.paymentUsedPoint}P</span></li>
+                                                <li class="list-group-item"><b>결제 수단:</b> <span class="badge bg-info text-dark">${detail.paymentMethod}</span></li>
+                                                <li class="list-group-item"><b>결제 상태:</b> <span class="badge bg-${detail.paymentStatus eq 'paid' ? 'success' : (detail.paymentStatus eq 'cancelled' ? 'danger' : 'secondary')}">${detail.paymentStatus}</span></li>
+                                                <li class="list-group-item"><b>결제 생성일:</b> ${detail.paymentCreatedAt}</li>
+                                                <li class="list-group-item"><b>결제 승인일:</b> ${detail.paymentPaidAt}</li>
+                                                <li class="list-group-item"><b>결제 취소일:</b> ${detail.paymentCancelledAt}</li>
+                                                <li class="list-group-item"><b>최종 수정일:</b> ${detail.paymentUpdatedAt}</li>
+                                                <li class="list-group-item"><b>영수증:</b> <c:if test="${not empty detail.paymentReceiptUrl}"><a href="${detail.paymentReceiptUrl}" target="_blank" class="btn btn-outline-primary btn-sm">영수증 보기</a></c:if></li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- 결제자 정보 -->
+                                <div class="col-md-6">
+                                    <div class="card h-100 shadow-sm">
+                                        <div class="card-header bg-primary text-white"><b>결제자 정보</b></div>
+                                        <div class="card-body">
+                                            <ul class="list-group list-group-flush">
+                                                <li class="list-group-item"><b>이름:</b> ${detail.paymentBuyerName}</li>
+                                                <li class="list-group-item"><b>이메일:</b> ${detail.paymentBuyerEmail}</li>
+                                                <li class="list-group-item"><b>전화번호:</b> ${detail.paymentBuyerTel}</li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <hr class="my-4"/>
+                            <!-- 사용자 정보 -->
+                            <div class="row g-4">
+                                <div class="col-md-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-secondary text-white"><b>사용자 정보</b></div>
+                                        <div class="card-body">
+                                            <div class="row align-items-center">
+                                                <div class="col-md-2 text-center">
+                                                    <c:choose>
+                                                        <c:when test="${not empty detail.usersProfile}">
+                                                            <img src="${detail.usersProfile}" alt="프로필 이미지" class="rounded-circle border" style="width:80px;height:80px;object-fit:cover;">
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <div class="rounded-circle bg-success text-white d-flex align-items-center justify-content-center" style="width:80px;height:80px;font-size:2rem;">${detail.usersName.substring(0, 1)}</div>
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                </div>
+                                                <div class="col-md-10">
+                                                    <ul class="list-group list-group-flush">
+                                                        <li class="list-group-item"><b>이름:</b> ${detail.usersName}</li>
+                                                        <li class="list-group-item"><b>이메일:</b> ${detail.usersEmail}</li>
+                                                        <li class="list-group-item"><b>전화번호:</b> ${detail.usersTel}</li>
+                                                        <li class="list-group-item"><b>성별:</b> ${detail.usersGender}</li>
+                                                        <li class="list-group-item"><b>보유 포인트:</b> <span class="text-warning fw-bold">${detail.usersPoint}</span></li>
+                                                        <li class="list-group-item"><b>로그인 타입:</b> <span class="badge bg-info text-dark">${detail.usersLoginType}</span></li>
+                                                        <li class="list-group-item"><b>계정 상태:</b> <span class="badge bg-${detail.usersStatus eq 'active' ? 'success' : 'danger'}">${detail.usersStatus}</span></li>
+                                                        <c:if test="${not empty detail.usersRejectedReason}">
+                                                            <li class="list-group-item"><b>거부 사유:</b> <span class="text-danger">${detail.usersRejectedReason}</span></li>
+                                                        </c:if>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </c:forEach>
+        </div>
+    </div>
+</div>
+<!-- Bootstrap JS (body 맨 아래에 추가) -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script>
+    window.APP_CTX = "${pageContext.request.contextPath}";
+
+    function cancelPayment(paymentId) {
+        if (confirm('정말로 이 결제를 취소하시겠습니까?')) {
+            // 결제 취소 로직 구현
+            $.ajax({
+                url: window.APP_CTX + '/admin/payment/cancel',
+                method: 'POST',
+                data: { paymentId: paymentId },
+                success: function(response) {
+                    alert('결제가 취소되었습니다.');
+                    location.reload();
+                },
+                error: function() {
+                    alert('결제 취소에 실패했습니다.');
+                }
+            });
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/admin/payment-management/home.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/payment-management/home.jsp
@@ -86,7 +86,7 @@
                 <table class="table align-middle table-hover">
                     <thead>
                     <tr>
-                        <th>결제 아이디</th>
+                        <th>통합 결제 아이디</th>
                         <th>사용자명</th>
                         <th>금액</th>
                         <th>사용 포인트</th>
@@ -95,6 +95,7 @@
                         <th>결제 생성일</th>
                         <th>영수증 URL</th>
                         <th>결제 상태</th>
+                        <th>자세히 보기</th>
                     </tr>
                     </thead>
                     <tbody id="paymentListBody">

--- a/src/main/webapp/css/admin/payment-management.css
+++ b/src/main/webapp/css/admin/payment-management.css
@@ -159,3 +159,18 @@ body {
 tr td {
     text-align: center;
 }
+
+.detail-button {
+    background-color: orange;
+    color: white;
+    font-size: 12px;
+    padding: 4px 10px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: center;
+}
+
+.detail-button:hover {
+    background-color: darkorange;
+}

--- a/src/main/webapp/js/admin/payment-management.js
+++ b/src/main/webapp/js/admin/payment-management.js
@@ -166,7 +166,7 @@ $(document).ready(function () {
     $(document).on('click', '.detail-button', function () {
         const $row = $(this).closest('tr');
         const paymentId = $row.find('td:first').text();
-        const url = ctx + '/admin/payment-management/detail?integratedp aymentId=' + paymentId;
+        const url = ctx + '/admin/payment-management/detail?integratedpaymentId=' + paymentId;
         window.location.href = url;
     });
 

--- a/src/main/webapp/js/admin/payment-management.js
+++ b/src/main/webapp/js/admin/payment-management.js
@@ -16,24 +16,27 @@ function renderPaymentRow(paymentList) {
 
     paymentList.forEach(payment => {
         const $row = $('<tr>');
-        $row.append($('<td>').text(payment.paymentId || ''));
+        $row.append($('<td>').text(payment.integratedpaymentId || ''));
         $row.append($('<td>').text(payment.usersName || ''));
         $row.append($('<td>').text(payment.paymentPaidAmount || '0'));
         $row.append($('<td>').text(payment.paymentUsedPoint || '0'));
-        $row.append($('<td>').text(payment.paymentMethod || '앱 내 결제'));
+        $row.append($('<td>').text(payment.paymentMethod || '미결제'));
         $row.append($('<td>').text(payment.paymentPgProvider || 'pg'));
         $row.append($('<td>').text(payment.paymentCreatedAt || ''));
 
         $row.append(
             $('<td>').append(
-                $('<a>')
-                    .attr('href', payment.paymentReceiptUrl || '#')
-                    .attr('target', '_blank')
-                    .text('영수증 보기')
+                payment.paymentReceiptUrl
+                    ? $('<a>')
+                        .attr('href', payment.paymentReceiptUrl)
+                        .attr('target', '_blank')
+                        .text('영수증 보기')
+                    : $('<span>').text('영수증 없음')
             )
         );
 
         $row.append($('<td>').text(payment.paymentStatus || ''));
+        $row.append($('<td>').append($('<button>').addClass('detail-button').text('자세히 보기 >>')));
         $tbody.append($row);
     });
 }
@@ -60,7 +63,14 @@ function searchPayment(query, page, size, paymentStatus = '') {
     $.ajax({
         url: ctx + '/admin/payment-management/search',
         type: 'GET',
-        data: {query, currentPage: page, pageSize: size, toDate: toDate, fromDate: fromDate, paymentStatus: paymentStatus},
+        data: {
+            query,
+            currentPage: page,
+            pageSize: size,
+            toDate: toDate,
+            fromDate: fromDate,
+            paymentStatus: paymentStatus
+        },
         success: function (response) {
             renderPaymentRow(response.list);
             console.log(response)
@@ -106,7 +116,7 @@ $(document).ready(function () {
         e.preventDefault();
         currentPage = 1;
         const query = $(this).find('input[name="query"]').val();
-        searchPayment(query, currentPage, $pageSize.val(),$status.val());
+        searchPayment(query, currentPage, $pageSize.val(), $status.val());
     });
 
     // 페이지 번호 클릭
@@ -115,35 +125,35 @@ $(document).ready(function () {
         const query = $('#searchPaymentForm').find('input[name="query"]').val();
         currentPage = parseInt($(this).text(), 10);
         updatePaginationUI($(this));
-        searchPayment(query, currentPage, $pageSize.val(),$status.val());
+        searchPayment(query, currentPage, $pageSize.val(), $status.val());
     });
 
     // Previous 클릭
     $pagination.on('click', '.previous .page-link', function (e) {
         e.preventDefault();
         const query = $('#searchPaymentForm').find('input[name="query"]').val();
-        searchPayment(query, firstPage - $pageSize.val(), $pageSize.val(),$status.val());
+        searchPayment(query, firstPage - $pageSize.val(), $pageSize.val(), $status.val());
     });
 
     // Next 클릭
     $pagination.on('click', '.next .page-link', function (e) {
         e.preventDefault();
         const query = $('#searchPaymentForm').find('input[name="query"]').val();
-        searchPayment(query, lastPage + 1, $pageSize.val(),$status.val());
+        searchPayment(query, lastPage + 1, $pageSize.val(), $status.val());
     });
 
     // 페이지 크기 변경
     $pageSize.on('change', function () {
         const query = $('#searchPaymentForm').find('input[name="query"]').val();
         currentPage = 1;
-        searchPayment(query, currentPage, $pageSize.val(),$status.val());
+        searchPayment(query, currentPage, $pageSize.val(), $status.val());
     });
 
     // 페이지 크기 변경
     $pageSize.on('change', function () {
         const query = $('#searchPaymentForm').find('input[name="query"]').val();
         currentPage = 1;
-        searchPayment(query, currentPage, $pageSize.val(),$status.val());
+        searchPayment(query, currentPage, $pageSize.val(), $status.val());
     });
 
     $status.on('change', function () {
@@ -152,5 +162,13 @@ $(document).ready(function () {
         searchPayment(query, currentPage, $pageSize.val(), $(this).val());
         console.log($status.val())
     });
-    searchPayment(query, currentPage, $pageSize.val(),$status.val());
+
+    $(document).on('click', '.detail-button', function () {
+        const $row = $(this).closest('tr');
+        const paymentId = $row.find('td:first').text();
+        const url = ctx + '/admin/payment-management/detail?integratedp aymentId=' + paymentId;
+        window.location.href = url;
+    });
+
+    searchPayment(query, currentPage, $pageSize.val(), $status.val());
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35, #129

## 📝작업 내용

> 기존 개별 결제가 모두 테이블에 보이던 것이 맞지 않다고 생각하여 통합 결제 아이디로 테이블을 볼 수 있도록 변경

> 결제 자세히 보기 구현

> 통합 결제 -> 개별 결제 페이지 이동 (자세히보기 클릭 시 이동한 화면에서 토글 버튼 클릭 시 개별 목록 보임) 

> 리드미 통합 내용으로 수정

### 스크린샷 (선택)

<img width="1897" height="705" alt="image" src="https://github.com/user-attachments/assets/f3f9ab5d-e18c-440f-b2c3-bc6b5cf38651" />
<img width="1918" height="590" alt="image" src="https://github.com/user-attachments/assets/2986b372-8911-49f7-8a2c-966abd290161" />
<img width="1619" height="683" alt="image" src="https://github.com/user-attachments/assets/8e463284-299c-4d86-9de1-2c95187f47c6" />
<img width="1579" height="521" alt="image" src="https://github.com/user-attachments/assets/33c2740c-73e3-479f-bb38-69145c400c5a" />

## 💬리뷰 요구사항(선택)

> 